### PR TITLE
Use rate.Limiter for controlling the throughput of rpc requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/holiman/uint256 v1.3.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/time v0.5.0
 )
 
 require (

--- a/scenarios/blob-combined/blob_combined.go
+++ b/scenarios/blob-combined/blob_combined.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	"github.com/sirupsen/logrus"
@@ -97,12 +99,23 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	txIdxCounter := uint64(0)
 	pendingCount := atomic.Int64{}
 	txCount := atomic.Uint64{}
-	startTime := time.Now()
 	var lastChan chan bool
 
 	s.logger.Infof("starting scenario: blob-combined")
 
+	initialRate := rate.Limit(float64(s.options.Throughput) / float64(utils.SecondsPerSlot))
+	if initialRate == 0 {
+		initialRate = rate.Inf
+	}
+	limiter := rate.NewLimiter(initialRate, int(s.options.Throughput))
+
 	for {
+		if err := limiter.Wait(context.Background()); err != nil {
+			s.logger.Debugf("rate limited: %s", err.Error())
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
 		txIdx := txIdxCounter
 		txIdxCounter++
 
@@ -151,11 +164,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 		count := txCount.Load() + uint64(pendingCount.Load())
 		if s.options.TotalCount > 0 && count >= s.options.TotalCount {
 			break
-		}
-		if s.options.Throughput > 0 {
-			for count/((uint64(time.Since(startTime).Seconds())/utils.SecondsPerSlot)+1) >= s.options.Throughput {
-				time.Sleep(100 * time.Millisecond)
-			}
 		}
 	}
 	<-lastChan

--- a/scenarios/blob-conflicting/blob_conflicting.go
+++ b/scenarios/blob-conflicting/blob_conflicting.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	"github.com/sirupsen/logrus"
@@ -93,12 +95,23 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	txIdxCounter := uint64(0)
 	pendingCount := atomic.Int64{}
 	txCount := atomic.Uint64{}
-	startTime := time.Now()
 	var lastChan chan bool
 
 	s.logger.Infof("starting scenario: blob-conflicting")
 
+	initialRate := rate.Limit(float64(s.options.Throughput) / float64(utils.SecondsPerSlot))
+	if initialRate == 0 {
+		initialRate = rate.Inf
+	}
+	limiter := rate.NewLimiter(initialRate, int(s.options.Throughput))
+
 	for {
+		if err := limiter.Wait(context.Background()); err != nil {
+			s.logger.Debugf("rate limited: %s", err.Error())
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
 		txIdx := txIdxCounter
 		txIdxCounter++
 
@@ -145,11 +158,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 		count := txCount.Load() + uint64(pendingCount.Load())
 		if s.options.TotalCount > 0 && count >= s.options.TotalCount {
 			break
-		}
-		if s.options.Throughput > 0 {
-			for count/((uint64(time.Since(startTime).Seconds())/utils.SecondsPerSlot)+1) >= s.options.Throughput {
-				time.Sleep(100 * time.Millisecond)
-			}
 		}
 	}
 	<-lastChan

--- a/scenarios/blob-replacements/blob_replacements.go
+++ b/scenarios/blob-replacements/blob_replacements.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	"github.com/sirupsen/logrus"
@@ -97,12 +99,23 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	txIdxCounter := uint64(0)
 	pendingCount := atomic.Int64{}
 	txCount := atomic.Uint64{}
-	startTime := time.Now()
 	var lastChan chan bool
 
 	s.logger.Infof("starting scenario: blob-replacements")
 
+	initialRate := rate.Limit(float64(s.options.Throughput) / float64(utils.SecondsPerSlot))
+	if initialRate == 0 {
+		initialRate = rate.Inf
+	}
+	limiter := rate.NewLimiter(initialRate, int(s.options.Throughput))
+
 	for {
+		if err := limiter.Wait(context.Background()); err != nil {
+			s.logger.Debugf("rate limited: %s", err.Error())
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
 		txIdx := txIdxCounter
 		txIdxCounter++
 
@@ -141,11 +154,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 		count := txCount.Load() + uint64(pendingCount.Load())
 		if s.options.TotalCount > 0 && count >= s.options.TotalCount {
 			break
-		}
-		if s.options.Throughput > 0 {
-			for count/((uint64(time.Since(startTime).Seconds())/utils.SecondsPerSlot)+1) >= s.options.Throughput {
-				time.Sleep(100 * time.Millisecond)
-			}
 		}
 	}
 	<-lastChan

--- a/scenarios/blobs/blobs.go
+++ b/scenarios/blobs/blobs.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	"github.com/sirupsen/logrus"
@@ -93,12 +95,23 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	txIdxCounter := uint64(0)
 	pendingCount := atomic.Int64{}
 	txCount := atomic.Uint64{}
-	startTime := time.Now()
 	var lastChan chan bool
 
 	s.logger.Infof("starting scenario: normal")
 
+	initialRate := rate.Limit(float64(s.options.Throughput) / float64(utils.SecondsPerSlot))
+	if initialRate == 0 {
+		initialRate = rate.Inf
+	}
+	limiter := rate.NewLimiter(initialRate, int(s.options.Throughput))
+
 	for {
+		if err := limiter.Wait(context.Background()); err != nil {
+			s.logger.Debugf("rate limited: %s", err.Error())
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
 		txIdx := txIdxCounter
 		txIdxCounter++
 
@@ -145,11 +158,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 		count := txCount.Load() + uint64(pendingCount.Load())
 		if s.options.TotalCount > 0 && count >= s.options.TotalCount {
 			break
-		}
-		if s.options.Throughput > 0 {
-			for count/((uint64(time.Since(startTime).Seconds())/utils.SecondsPerSlot)+1) >= s.options.Throughput {
-				time.Sleep(100 * time.Millisecond)
-			}
 		}
 	}
 	<-lastChan

--- a/scenarios/deploy-destruct/deploy_destruct.go
+++ b/scenarios/deploy-destruct/deploy_destruct.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -100,7 +102,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	txIdxCounter := uint64(0)
 	pendingCount := atomic.Int64{}
 	txCount := atomic.Uint64{}
-	startTime := time.Now()
 	var lastChan chan bool
 
 	s.logger.Infof("starting scenario: deploy-destruct")
@@ -112,7 +113,19 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	s.contractAddr = contractReceipt.ContractAddress
 	s.logger.Infof("deployed test contract: %v (confirmed in block #%v)", s.contractAddr.String(), contractReceipt.BlockNumber.String())
 
+	initialRate := rate.Limit(float64(s.options.Throughput) / float64(utils.SecondsPerSlot))
+	if initialRate == 0 {
+		initialRate = rate.Inf
+	}
+	limiter := rate.NewLimiter(initialRate, int(s.options.Throughput))
+
 	for {
+		if err := limiter.Wait(context.Background()); err != nil {
+			s.logger.Debugf("rate limited: %s", err.Error())
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
 		txIdx := txIdxCounter
 		txIdxCounter++
 
@@ -163,11 +176,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 		count := txCount.Load() + uint64(pendingCount.Load())
 		if s.options.TotalCount > 0 && count >= s.options.TotalCount {
 			break
-		}
-		if s.options.Throughput > 0 {
-			for count/((uint64(time.Since(startTime).Seconds())/utils.SecondsPerSlot)+1) >= s.options.Throughput {
-				time.Sleep(100 * time.Millisecond)
-			}
 		}
 	}
 	s.pendingWGroup.Wait()

--- a/scenarios/deploytx/deploytx.go
+++ b/scenarios/deploytx/deploytx.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
@@ -123,12 +125,23 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	txIdxCounter := uint64(0)
 	pendingCount := atomic.Int64{}
 	txCount := atomic.Uint64{}
-	startTime := time.Now()
 	var lastChan chan bool
 
 	s.logger.Infof("starting scenario: deploytx")
 
+	initialRate := rate.Limit(float64(s.options.Throughput) / float64(utils.SecondsPerSlot))
+	if initialRate == 0 {
+		initialRate = rate.Inf
+	}
+	limiter := rate.NewLimiter(initialRate, int(s.options.Throughput))
+
 	for {
+		if err := limiter.Wait(context.Background()); err != nil {
+			s.logger.Debugf("rate limited: %s", err.Error())
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
 		txIdx := txIdxCounter
 		txIdxCounter++
 
@@ -175,11 +188,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 		count := txCount.Load() + uint64(pendingCount.Load())
 		if s.options.TotalCount > 0 && count >= s.options.TotalCount {
 			break
-		}
-		if s.options.Throughput > 0 {
-			for count/((uint64(time.Since(startTime).Seconds())/utils.SecondsPerSlot)+1) >= s.options.Throughput {
-				time.Sleep(100 * time.Millisecond)
-			}
 		}
 	}
 	s.pendingWGroup.Wait()

--- a/scenarios/eoatx/eoatx.go
+++ b/scenarios/eoatx/eoatx.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"golang.org/x/time/rate"
 	"math/big"
 	"strings"
 	"sync"
@@ -101,13 +102,24 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	txIdxCounter := uint64(0)
 	pendingCount := atomic.Int64{}
 	txCount := atomic.Uint64{}
-	startTime := time.Now()
 
 	s.logger.Infof("starting scenario: eoatx")
 
 	var lastChan chan bool
 
+	initialRate := rate.Limit(float64(s.options.Throughput) / float64(utils.SecondsPerSlot))
+	if initialRate == 0 {
+		initialRate = rate.Inf
+	}
+	limiter := rate.NewLimiter(initialRate, int(s.options.Throughput))
+
 	for {
+		if err := limiter.Wait(context.Background()); err != nil {
+			s.logger.Debugf("rate limited: %s", err.Error())
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
 		txIdx := txIdxCounter
 		txIdxCounter++
 
@@ -155,11 +167,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 		count := txCount.Load() + uint64(pendingCount.Load())
 		if s.options.TotalCount > 0 && count >= s.options.TotalCount {
 			break
-		}
-		if s.options.Throughput > 0 {
-			for count/((uint64(time.Since(startTime).Seconds())/utils.SecondsPerSlot)+1) >= s.options.Throughput {
-				time.Sleep(100 * time.Millisecond)
-			}
 		}
 	}
 

--- a/scenarios/erctx/erctx.go
+++ b/scenarios/erctx/erctx.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -100,7 +102,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	txIdxCounter := uint64(0)
 	pendingCount := atomic.Int64{}
 	txCount := atomic.Uint64{}
-	startTime := time.Now()
 	var lastChan chan bool
 
 	s.logger.Infof("starting scenario: erctx")
@@ -112,7 +113,19 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	s.contractAddr = contractReceipt.ContractAddress
 	s.logger.Infof("deployed token contract: %v (confirmed in block #%v)", s.contractAddr.String(), contractReceipt.BlockNumber.String())
 
+	initialRate := rate.Limit(float64(s.options.Throughput) / float64(utils.SecondsPerSlot))
+	if initialRate == 0 {
+		initialRate = rate.Inf
+	}
+	limiter := rate.NewLimiter(initialRate, int(s.options.Throughput))
+
 	for {
+		if err := limiter.Wait(context.Background()); err != nil {
+			s.logger.Debugf("rate limited: %s", err.Error())
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
 		txIdx := txIdxCounter
 		txIdxCounter++
 
@@ -159,11 +172,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 		count := txCount.Load() + uint64(pendingCount.Load())
 		if s.options.TotalCount > 0 && count >= s.options.TotalCount {
 			break
-		}
-		if s.options.Throughput > 0 {
-			for count/((uint64(time.Since(startTime).Seconds())/utils.SecondsPerSlot)+1) >= s.options.Throughput {
-				time.Sleep(100 * time.Millisecond)
-			}
 		}
 	}
 

--- a/scenarios/setcodetx/setcodetx.go
+++ b/scenarios/setcodetx/setcodetx.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
@@ -122,13 +124,24 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 	txIdxCounter := uint64(0)
 	pendingCount := atomic.Int64{}
 	txCount := atomic.Uint64{}
-	startTime := time.Now()
 
 	s.logger.Infof("starting scenario: eoatx")
 
 	var lastChan chan bool
 
+	initialRate := rate.Limit(float64(s.options.Throughput) / float64(utils.SecondsPerSlot))
+	if initialRate == 0 {
+		initialRate = rate.Inf
+	}
+	limiter := rate.NewLimiter(initialRate, int(s.options.Throughput))
+
 	for {
+		if err := limiter.Wait(context.Background()); err != nil {
+			s.logger.Debugf("rate limited: %s", err.Error())
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
 		txIdx := txIdxCounter
 		txIdxCounter++
 
@@ -176,11 +189,6 @@ func (s *Scenario) Run(tester *tester.Tester) error {
 		count := txCount.Load() + uint64(pendingCount.Load())
 		if s.options.TotalCount > 0 && count >= s.options.TotalCount {
 			break
-		}
-		if s.options.Throughput > 0 {
-			for count/((uint64(time.Since(startTime).Seconds())/utils.SecondsPerSlot)+1) >= s.options.Throughput {
-				time.Sleep(100 * time.Millisecond)
-			}
 		}
 	}
 


### PR DESCRIPTION
This PR refactors the current throughput control mechanism in spamoor by replacing the logic that uses startTime and current time to calculate the allowed transaction count with a rate limiter from `golang.org/x/time/rate`. The current approach involves calculating elapsed time and adjusting throughput accordingly, which can be a bit opaque. Using a rate limiter makes the intention clearer.

Also, this change can make dynamic adjustment of throughput more easy. (like time-based throughput changes to simulate real-world request spikes).

Please let me know if you have any concerns with this change! 😄 