### PR TITLE
Use 1gwei fee/tip cap for blob transactions

### DIFF
--- a/scenarios/blobs/blobs.go
+++ b/scenarios/blobs/blobs.go
@@ -179,13 +179,13 @@ func (s *Scenario) sendBlobTx(txIdx uint64) (*types.Transaction, *txbuilder.Clie
 	var blobFee *big.Int
 
 	if s.options.BaseFee > 0 {
-		feeCap = new(big.Int).Mul(big.NewInt(int64(s.options.BaseFee)), big.NewInt(1000000))
+		feeCap = new(big.Int).Mul(big.NewInt(int64(s.options.BaseFee)), big.NewInt(1000000000))
 	}
 	if s.options.TipFee > 0 {
-		tipCap = new(big.Int).Mul(big.NewInt(int64(s.options.TipFee)), big.NewInt(1000000))
+		tipCap = new(big.Int).Mul(big.NewInt(int64(s.options.TipFee)), big.NewInt(1000000000))
 	}
 	if s.options.BlobFee > 0 {
-		blobFee = new(big.Int).Mul(big.NewInt(int64(s.options.BlobFee)), big.NewInt(1000000))
+		blobFee = new(big.Int).Mul(big.NewInt(int64(s.options.BlobFee)), big.NewInt(1000000000))
 	}
 
 	if feeCap == nil || tipCap == nil {
@@ -196,14 +196,14 @@ func (s *Scenario) sendBlobTx(txIdx uint64) (*types.Transaction, *txbuilder.Clie
 		}
 	}
 
-	if feeCap.Cmp(big.NewInt(1000000)) < 0 {
-		feeCap = big.NewInt(1000000)
+	if feeCap.Cmp(big.NewInt(1000000000)) < 0 {
+		feeCap = big.NewInt(1000000000)
 	}
-	if tipCap.Cmp(big.NewInt(1000000)) < 0 {
-		tipCap = big.NewInt(1000000)
+	if tipCap.Cmp(big.NewInt(1000000000)) < 0 {
+		tipCap = big.NewInt(1000000000)
 	}
 	if blobFee == nil {
-		blobFee = big.NewInt(1000000)
+		blobFee = big.NewInt(1000000000)
 	}
 
 	blobCount := uint64(rand.Int63n(int64(s.options.Sidecars)) + 1)


### PR DESCRIPTION
Original code had 1000000wei set as feeCap/tipCap/blobFee, which is too low to be included in the txpool for some clients, and likely a typo since it's different from other tx types in spamoor. 

This PR increases the feeCaps to 1gwei which is a sensible fee for it to be included in a txpool