### PR TITLE
Use go1.23 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build env
-FROM golang:1.22 AS build-env
+FROM golang:1.23 AS build-env
 COPY go.mod go.sum /src/
 WORKDIR /src
 RUN go mod download


### PR DESCRIPTION
`go.mod` is updated to use go 1.23. 
This PR updates the dockerfile to use go1.23 in the build environment as well. 