### PR TITLE
added block reorg handling

### DIFF
--- a/cmd/spamoor/main.go
+++ b/cmd/spamoor/main.go
@@ -50,12 +50,6 @@ func main() {
 	defer cancel()
 
 	// init logger
-	if cliArgs.trace {
-		logrus.SetLevel(logrus.TraceLevel)
-	} else if cliArgs.verbose {
-		logrus.SetLevel(logrus.DebugLevel)
-	}
-
 	logger := logrus.StandardLogger()
 
 	logger.WithFields(logrus.Fields{
@@ -98,6 +92,12 @@ func main() {
 	scenario.Flags(flags)
 	cliArgs.rpchosts = nil
 	flags.Parse(os.Args)
+
+	if cliArgs.trace {
+		logrus.SetLevel(logrus.TraceLevel)
+	} else if cliArgs.verbose {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 
 	// start client pool
 	rpcHosts := []string{}

--- a/txbuilder/txpool.go
+++ b/txbuilder/txpool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"runtime/debug"
+	"slices"
 	"sync"
 	"time"
 
@@ -742,6 +743,7 @@ func (pool *TxPool) handleReorg(ctx context.Context, client *Client, blockNumber
 	}
 
 	// re-process the new parent blocks
+	slices.Reverse(newBlockParents)
 	for _, parentBlock := range newBlockParents {
 		pool.processBlockTxs(ctx, client, parentBlock.NumberU64(), parentBlock, chainId)
 	}

--- a/txbuilder/txpool.go
+++ b/txbuilder/txpool.go
@@ -15,18 +15,47 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// BlockInfo represents information about a processed block
+type BlockInfo struct {
+	Number     uint64
+	Hash       common.Hash
+	ParentHash common.Hash
+	Timestamp  uint64
+}
+
+// TxInfo represents information about a confirmed transaction
+type TxInfo struct {
+	TxHash     common.Hash
+	From       common.Address
+	To         *common.Address
+	Tx         *types.Transaction
+	FromWallet *Wallet
+	ToWallet   *Wallet
+	Options    *SendTransactionOptions
+}
+
 type TxPool struct {
 	options          *TxPoolOptions
 	wallets          map[common.Address]*Wallet
 	walletsMutex     sync.RWMutex
 	processStaleChan chan uint64
 	lastBlockNumber  uint64
+
+	// Block tracking for reorg detection
+	blocksMutex sync.RWMutex
+	blocks      map[uint64]*BlockInfo
+	reorgDepth  int // Number of blocks to keep in memory for reorg tracking
+
+	// Transaction tracking for reorg recovery
+	txsMutex     sync.RWMutex
+	confirmedTxs map[uint64][]*TxInfo
 }
 
 type TxPoolOptions struct {
 	Context          context.Context
 	GetClientFn      func(index int, random bool) *Client
 	GetClientCountFn func() int
+	ReorgDepth       int // Number of blocks to keep in memory for reorg tracking
 }
 
 type TxConfirmFn func(tx *types.Transaction, receipt *types.Receipt, err error)
@@ -48,10 +77,17 @@ func NewTxPool(options *TxPoolOptions) *TxPool {
 		options:          options,
 		wallets:          map[common.Address]*Wallet{},
 		processStaleChan: make(chan uint64, 1),
+		blocks:           map[uint64]*BlockInfo{},
+		confirmedTxs:     map[uint64][]*TxInfo{},
+		reorgDepth:       10, // Default value
 	}
 
 	if options.Context == nil {
 		options.Context = context.Background()
+	}
+
+	if options.ReorgDepth > 0 {
+		pool.reorgDepth = options.ReorgDepth
 	}
 
 	go pool.runTxPoolLoop()
@@ -69,16 +105,21 @@ func (pool *TxPool) runTxPoolLoop() {
 
 	highestBlockNumber := uint64(0)
 	for {
-		newHighestBlockNumber := pool.getHighestBlockNumber()
+		newHighestBlockNumber, clients := pool.getHighestBlockNumber()
 		if newHighestBlockNumber > highestBlockNumber {
 			if highestBlockNumber > 0 || newHighestBlockNumber < 10 {
-				for blockNumber := highestBlockNumber + 1; blockNumber <= newHighestBlockNumber; blockNumber++ {
-					err := pool.processBlock(pool.options.Context, blockNumber)
-					if err != nil {
-						logrus.WithError(err).Errorf("error processing block %v", blockNumber)
+				blockNumber := highestBlockNumber + 1
+				for _, client := range clients {
+					for ; blockNumber <= newHighestBlockNumber; blockNumber++ {
+						err := pool.processBlock(pool.options.Context, client, blockNumber)
+						if err != nil {
+							logrus.WithError(err).Errorf("error processing block %v", blockNumber)
+						}
+					}
+					if blockNumber == newHighestBlockNumber {
+						break
 					}
 				}
-
 			}
 			highestBlockNumber = newHighestBlockNumber
 
@@ -124,7 +165,7 @@ func (pool *TxPool) processStaleTransactionsLoop() {
 	}
 }
 
-func (pool *TxPool) processBlock(ctx context.Context, blockNumber uint64) error {
+func (pool *TxPool) processBlock(ctx context.Context, client *Client, blockNumber uint64) error {
 	pool.lastBlockNumber = blockNumber
 
 	pool.walletsMutex.RLock()
@@ -145,14 +186,46 @@ func (pool *TxPool) processBlock(ctx context.Context, blockNumber uint64) error 
 		return nil
 	}
 
-	t1 := time.Now()
-	blockBody := pool.getBlockBody(ctx, blockNumber)
+	blockBody := pool.getBlockBody(ctx, client, blockNumber)
 	if blockBody == nil {
 		return fmt.Errorf("could not load block body")
 	}
 
+	// Check for reorg by comparing parent hash
+	pool.blocksMutex.RLock()
+	lastBlock, hasLastBlock := pool.blocks[blockNumber-1]
+	pool.blocksMutex.RUnlock()
+
+	if hasLastBlock && lastBlock.Hash != blockBody.ParentHash() {
+		logrus.Warnf("Detected chain reorganization at block %d. Parent hash mismatch: expected %s, got %s",
+			blockNumber, lastBlock.Hash.Hex(), blockBody.ParentHash().Hex())
+
+		// Handle reorg
+		pool.handleReorg(ctx, client, blockNumber, blockBody, chainId)
+	}
+
+	// Store block info
+	pool.blocksMutex.Lock()
+	pool.blocks[blockNumber] = &BlockInfo{
+		Number:     blockNumber,
+		Hash:       blockBody.Hash(),
+		ParentHash: blockBody.ParentHash(),
+		Timestamp:  blockBody.Time(),
+	}
+
+	// Clean up old blocks
+	if blockNumber > uint64(pool.reorgDepth) {
+		delete(pool.blocks, blockNumber-uint64(pool.reorgDepth))
+	}
+	pool.blocksMutex.Unlock()
+
+	return pool.processBlockTxs(ctx, client, blockNumber, blockBody, chainId)
+}
+
+func (pool *TxPool) processBlockTxs(ctx context.Context, client *Client, blockNumber uint64, blockBody *types.Block, chainId *big.Int) error {
+	t1 := time.Now()
 	txCount := len(blockBody.Transactions())
-	receipts, err := pool.getBlockReceipts(ctx, blockNumber, txCount)
+	receipts, err := pool.getBlockReceipts(ctx, client, blockNumber, txCount)
 	if receipts == nil {
 		return fmt.Errorf("could not load block receipts: %w", err)
 	}
@@ -177,20 +250,48 @@ func (pool *TxPool) processBlock(ctx context.Context, blockNumber uint64) error 
 			continue
 		}
 
+		txHash := tx.Hash()
 		fromWallet := pool.getWallet(txFrom)
+		toAddr := tx.To()
+		toWallet := (*Wallet)(nil)
+		if toAddr != nil {
+			toWallet = pool.getWallet(*toAddr)
+		}
+
+		if fromWallet != nil || toWallet != nil {
+			pool.txsMutex.Lock()
+			pool.confirmedTxs[blockNumber] = append(pool.confirmedTxs[blockNumber], &TxInfo{
+				TxHash:     txHash,
+				From:       txFrom,
+				To:         tx.To(),
+				Tx:         tx,
+				FromWallet: fromWallet,
+				ToWallet:   toWallet,
+			})
+			pool.txsMutex.Unlock()
+		}
+
 		if fromWallet != nil {
 			confirmCount++
 			walletMap[txFrom] = true
 			pool.processTransactionInclusion(blockNumber, fromWallet, tx, receipt)
 		}
 
-		toAddr := tx.To()
-		if toAddr != nil {
-			toWallet := pool.getWallet(*toAddr)
-			if toWallet != nil {
-				pool.processTransactionReceival(toWallet, tx)
+		if toWallet != nil {
+			pool.processTransactionReceival(toWallet, tx)
+		}
+	}
+
+	// Clean up old confirmed transactions
+	if blockNumber > uint64(pool.reorgDepth) {
+		oldBlock := blockNumber - uint64(pool.reorgDepth)
+		pool.txsMutex.Lock()
+		for blockNumber := range pool.confirmedTxs {
+			if blockNumber < oldBlock {
+				delete(pool.confirmedTxs, blockNumber)
 			}
 		}
+		pool.txsMutex.Unlock()
 	}
 
 	logrus.Infof("processed block %v:  %v total tx, %v tx confirmed from %v wallets (%v, %v)", blockNumber, txCount, confirmCount, len(walletMap), loadingTime, time.Since(t1))
@@ -198,7 +299,7 @@ func (pool *TxPool) processBlock(ctx context.Context, blockNumber uint64) error 
 	return nil
 }
 
-func (pool *TxPool) getHighestBlockNumber() uint64 {
+func (pool *TxPool) getHighestBlockNumber() (uint64, []*Client) {
 	clientCount := pool.options.GetClientCountFn()
 	wg := &sync.WaitGroup{}
 
@@ -206,6 +307,8 @@ func (pool *TxPool) getHighestBlockNumber() uint64 {
 	highestBlockNumberMutex := sync.Mutex{}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
+
+	highestBlockNumberClients := []*Client{}
 
 	for i := 0; i < clientCount; i++ {
 		client := pool.options.GetClientFn(i, false)
@@ -224,64 +327,48 @@ func (pool *TxPool) getHighestBlockNumber() uint64 {
 			highestBlockNumberMutex.Lock()
 			if blockNumber > highestBlockNumber {
 				highestBlockNumber = blockNumber
+				highestBlockNumberClients = []*Client{client}
+			} else if blockNumber == highestBlockNumber {
+				highestBlockNumberClients = append(highestBlockNumberClients, client)
 			}
 			highestBlockNumberMutex.Unlock()
 		}()
 	}
 
 	wg.Wait()
-	return highestBlockNumber
+	return highestBlockNumber, highestBlockNumberClients
 }
 
-func (pool *TxPool) getBlockBody(ctx context.Context, blockNumber uint64) *types.Block {
-	clientCount := pool.options.GetClientCountFn()
-
+func (pool *TxPool) getBlockBody(ctx context.Context, client *Client, blockNumber uint64) *types.Block {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	for i := 0; i < clientCount; i++ {
-		client := pool.options.GetClientFn(i, false)
-		if client == nil {
-			continue
-		}
-
-		blockBody, err := client.client.BlockByNumber(ctx, big.NewInt(int64(blockNumber)))
-		if err == nil {
-			return blockBody
-		}
+	blockBody, err := client.client.BlockByNumber(ctx, big.NewInt(int64(blockNumber)))
+	if err == nil {
+		return blockBody
 	}
 
 	return nil
 }
 
-func (pool *TxPool) getBlockReceipts(ctx context.Context, blockNumber uint64, txCount int) ([]*types.Receipt, error) {
-	clientCount := pool.options.GetClientCountFn()
-
+func (pool *TxPool) getBlockReceipts(ctx context.Context, client *Client, blockNumber uint64, txCount int) ([]*types.Receipt, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	var receiptErr error
 	blockNum := rpc.BlockNumber(blockNumber)
 
-	for i := 0; i < clientCount; i++ {
-		client := pool.options.GetClientFn(i, false)
-		if client == nil {
-			continue
+	blockReceipts, err := client.client.BlockReceipts(ctx, rpc.BlockNumberOrHash{
+		BlockNumber: &blockNum,
+	})
+	if err != nil {
+		receiptErr = err
+	} else {
+		if len(blockReceipts) != txCount {
+			return nil, fmt.Errorf("block %v has %v receipts, expected %v", blockNumber, len(blockReceipts), txCount)
 		}
 
-		blockReceipts, err := client.client.BlockReceipts(ctx, rpc.BlockNumberOrHash{
-			BlockNumber: &blockNum,
-		})
-		if err != nil {
-			receiptErr = err
-		} else {
-			if len(blockReceipts) != txCount {
-				logrus.Warnf("block %v has %v receipts, expected %v", blockNumber, len(blockReceipts), txCount)
-				continue
-			}
-
-			return blockReceipts, nil
-		}
+		return blockReceipts, nil
 	}
 
 	return nil, receiptErr
@@ -294,58 +381,75 @@ func (pool *TxPool) getWallet(address common.Address) *Wallet {
 }
 
 func (pool *TxPool) SendTransaction(ctx context.Context, wallet *Wallet, tx *types.Transaction, options *SendTransactionOptions) error {
-	var confirmCtx context.Context
+	return pool.addPendingTransaction(ctx, wallet, tx, options, func() error {
+		var err error
 
-	var confirmCancel context.CancelFunc
-
-	if options.OnConfirm != nil || options.MaxRebroadcasts > 0 {
-		confirmCtx, confirmCancel = context.WithCancel(ctx)
-		wg := &sync.WaitGroup{}
-		wg.Add(1)
-
-		go func() {
-			var receipt *types.Receipt
-
-			var err error
-
-			defer confirmCancel()
-
-			if options.OnConfirm != nil {
-				defer func() {
-					options.OnConfirm(tx, receipt, err)
-				}()
+		clientCount := pool.options.GetClientCountFn()
+		for i := 0; i < clientCount; i++ {
+			client := options.Client
+			if client == nil || i > 0 {
+				client = pool.options.GetClientFn(i+options.ClientsStartOffset, false)
+			}
+			if client == nil {
+				continue
 			}
 
-			receipt, err = pool.awaitTransaction(confirmCtx, wallet, tx, wg)
-			if confirmCtx.Err() != nil {
-				err = nil
-			}
-		}()
+			err = client.SendTransactionCtx(ctx, tx)
 
-		wg.Wait()
-	}
+			if options.LogFn != nil {
+				options.LogFn(client, i, 0, err)
+			}
+
+			if err == nil {
+				break
+			}
+		}
+
+		return err
+	})
+}
+
+func (pool *TxPool) addPendingTransaction(ctx context.Context, wallet *Wallet, tx *types.Transaction, options *SendTransactionOptions, submitCb func() error) error {
+	confirmCtx, confirmCancel := context.WithCancel(ctx)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		var receipt *types.Receipt
+
+		var err error
+
+		defer confirmCancel()
+
+		if options.OnConfirm != nil {
+			defer func() {
+				options.OnConfirm(tx, receipt, err)
+			}()
+		}
+
+		receipt, err = pool.awaitTransaction(confirmCtx, wallet, tx, wg)
+		if confirmCtx.Err() != nil {
+			err = nil
+		}
+
+		if receipt != nil {
+			pool.txsMutex.Lock()
+			for _, tx := range pool.confirmedTxs[receipt.BlockNumber.Uint64()] {
+				if tx.TxHash == receipt.TxHash {
+					tx.Options = options
+					break
+				}
+			}
+			pool.txsMutex.Unlock()
+		}
+	}()
+
+	wg.Wait()
 
 	var err error
 
-	clientCount := pool.options.GetClientCountFn()
-	for i := 0; i < clientCount; i++ {
-		client := options.Client
-		if client == nil || i > 0 {
-			client = pool.options.GetClientFn(i+options.ClientsStartOffset, false)
-		}
-		if client == nil {
-			continue
-		}
-
-		err = client.SendTransactionCtx(ctx, tx)
-
-		if options.LogFn != nil {
-			options.LogFn(client, i, 0, err)
-		}
-
-		if err == nil {
-			break
-		}
+	if submitCb != nil {
+		err = submitCb()
 	}
 
 	if err != nil {
@@ -529,4 +633,118 @@ func (pool *TxPool) loadTransactionReceipt(ctx context.Context, tx *types.Transa
 			return nil
 		}
 	}
+}
+
+// handleReorg handles a chain reorganization
+func (pool *TxPool) handleReorg(ctx context.Context, client *Client, blockNumber uint64, newBlock *types.Block, chainId *big.Int) error {
+	newBlockParents := []*types.Block{}
+
+	// let's assume a reorg of 2 blocks:
+	// old chain: 1 -> 2 -> 3a -> 4a
+	// new chain: 1 -> 2 -> 3b -> 4b
+
+	// we'll find out about this reorg when receiving block 4b
+	// we need to:
+	// 1. find the common ancestor of the two blocks (block 2), by loading the new parents (3b)
+	// 2. find all the transactions that were reorged out in block 3a - 4a
+	// 3. add reorged out transactions as pending txs, reset affected wallets nonce state
+	// 4. remove blocks 3a - 4a from the pool
+	// 5. re-process block 3b (4b will be processed after the reorg processing completes)
+
+	// find the common ancestor
+	block := newBlock
+	for {
+		if block.NumberU64() == 0 {
+			break
+		}
+
+		blockNumber := block.NumberU64() - 1
+		if pool.blocks[blockNumber] == nil {
+			break
+		}
+
+		if pool.blocks[blockNumber].Hash == block.ParentHash() {
+			break
+		}
+
+		parentBlockBody := pool.getBlockBody(ctx, client, blockNumber)
+		if parentBlockBody == nil {
+			return fmt.Errorf("could not load block body for new parent block %v", blockNumber)
+		}
+
+		newBlockParents = append(newBlockParents, parentBlockBody)
+		block = parentBlockBody
+	}
+
+	reorgBaseBlock := block
+
+	// find all the transactions that were reorged out
+	pool.txsMutex.Lock()
+	reorgedOutTxs := []*TxInfo{}
+	for blockNum := reorgBaseBlock.NumberU64(); blockNum <= blockNumber; blockNum++ {
+		blockTxs := pool.confirmedTxs[blockNum]
+		if blockTxs == nil {
+			continue
+		}
+
+		reorgedOutTxs = append(reorgedOutTxs, blockTxs...)
+	}
+
+	// remove reorged out blocks & txs from cache
+	pool.blocksMutex.Lock()
+	for blockNum := reorgBaseBlock.NumberU64() + 1; blockNum <= blockNumber; blockNum++ {
+		delete(pool.blocks, blockNum)
+		delete(pool.confirmedTxs, blockNum)
+	}
+	pool.blocksMutex.Unlock()
+	pool.txsMutex.Unlock()
+
+	// add reorged out txs as pending txs, reset affected wallets nonce state
+	resetWallets := map[common.Address]bool{}
+	for _, tx := range reorgedOutTxs {
+		if tx.FromWallet != nil {
+			if !resetWallets[tx.From] {
+				resetWallets[tx.From] = true
+
+				tx.FromWallet.txNonceMutex.Lock()
+				tx.FromWallet.confirmedNonce = tx.Tx.Nonce()
+				tx.FromWallet.txNonceMutex.Unlock()
+			}
+
+			// add tx as pending tx
+			txOptions := &SendTransactionOptions{
+				Client: client,
+				OnConfirm: func(tx *types.Transaction, receipt *types.Receipt, err error) {
+					if err != nil {
+						logrus.WithError(err).Errorf("error confirming reorged out tx %v", tx.Hash())
+					} else {
+						logrus.Infof("reorged out tx %v confirmed", tx.Hash())
+					}
+				},
+				RebroadcastInterval: 30 * time.Second,
+				MaxRebroadcasts:     10,
+			}
+
+			if tx.Options != nil {
+				txOptions.LogFn = tx.Options.LogFn
+			}
+
+			err := pool.addPendingTransaction(ctx, tx.FromWallet, tx.Tx, txOptions, nil)
+			if err != nil {
+				logrus.WithError(err).Errorf("error adding pending transaction for reorged out tx %v", tx.Tx.Hash())
+			}
+		}
+
+		if tx.ToWallet != nil {
+			// reverse processTransactionReceival
+			tx.ToWallet.balance = tx.ToWallet.balance.Sub(tx.ToWallet.balance, tx.Tx.Value())
+		}
+	}
+
+	// re-process the new parent blocks
+	for _, parentBlock := range newBlockParents {
+		pool.processBlockTxs(ctx, client, parentBlock.NumberU64(), parentBlock, chainId)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR adds logic to handle block reorgs properly.

* Store block bodies & confirmed transactions for a certain number of blocks in memory
* Detect chain reorgs by checking the parent hashes of new blocks
* In case of an reorg:
  - "revert" all blocks up to the fork ancestor
  - add reorged out transactions as pending txs (with rebroadcasthing enabled, so they get resubmitted if not picked up by a later block)
  - process new parent blocks & new head
  