### PR TITLE
implement `calltx` scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Spamoor provides multiple scenarios for different transaction types:
 |----------|-------------|
 | [`eoatx`](./scenarios/eoatx/README.md) | **EOA Transactions**<br>Send standard EOA transactions with configurable amounts and targets |
 | [`erctx`](./scenarios/erctx/README.md) | **ERC20 Transactions**<br>Deploy a ERC20 contract and transfer tokens |
+| [`calltx`](./scenarios/calltx/README.md) | **Contract Calls**<br>Deploy a contract and repeatedly call a function on it |
 | [`deploytx`](./scenarios/deploytx/README.md) | **Contract Deployments**<br>Deploy contracts with custom bytecode |
 | [`deploy-destruct`](./scenarios/deploy-destruct/README.md) | **Self-Destruct Deployments**<br>Deploy contracts that self-destruct |
 | [`setcodetx`](./scenarios/setcodetx/README.md) | **Set Code Transactions**<br>Send EIP-7702 setcode-transactions with various settings |

--- a/scenarios/calltx/README.md
+++ b/scenarios/calltx/README.md
@@ -1,0 +1,132 @@
+# Contract Call Transactions
+
+Deploy a contract and repeatedly call a function on it.
+
+## Usage
+
+```bash
+spamoor calltx [flags]
+```
+
+## Configuration
+
+### Base Settings (required)
+- `--privkey` - Private key of the sending wallet
+- `--rpchost` - RPC endpoint(s) to send transactions to
+
+### Volume Control (either -c or -t required)
+- `-c, --count` - Total number of call transactions to send
+- `-t, --throughput` - Call transactions to send per slot
+- `--max-pending` - Maximum number of pending transactions
+
+### Contract Settings (required)
+- `--contract-code` - Contract bytecode to deploy (hex string)
+- `--contract-file` - Contract file to deploy (local file or HTTP URL)
+- `--contract-args` - Constructor arguments for the contract (hex string)
+- `--call-data` - Data to pass to the function calls (hex string)
+
+### ABI-Based Call Data (alternative to --call-data)
+- `--call-abi` - JSON ABI of the contract for function calls
+- `--call-abi-file` - JSON ABI file of the contract for function calls (local file or HTTP URL)
+- `--call-fn-name` - Function name to call (requires --call-abi or --call-abi-file)
+- `--call-fn-sig` - Function signature to call (alternative to --call-abi/--call-abi-file)
+- `--call-args` - JSON array of arguments to pass to the function
+
+#### ABI Call Arguments Placeholders
+The `--call-args` parameter supports the following placeholders:
+- `{txid}` - Transaction index/ID
+- `{random}` - Random uint256 value
+- `{random:N}` - Random number between 0 and N
+- `{randomaddr}` - Random Ethereum address
+
+### Transaction Settings
+- `--basefee` - Max fee per gas in gwei (default: 20)
+- `--tipfee` - Max tip per gas in gwei (default: 2)
+- `--deploy-gas-limit` - Gas limit for deployment transaction (default: 2000000)
+- `--gas-limit` - Gas limit for call transactions (default: 1000000)
+- `--amount` - ETH amount to send with each call in gwei (default: 20)
+- `--random-amount` - Use random amounts (with --amount as limit)
+- `--random-target` - Use random destination addresses
+- `--rebroadcast` - Seconds to wait before rebroadcasting (default: 120)
+
+### Wallet Management
+- `--max-wallets` - Maximum number of child wallets to use
+- `--refill-amount` - ETH amount to fund each child wallet (default: 5)
+- `--refill-balance` - Minimum ETH balance before refilling (default: 2)
+- `--refill-interval` - Seconds between balance checks (default: 300)
+
+### Client Settings
+- `--client-group` - Client group to use for sending transactions
+
+### Debug Options
+- `-v, --verbose` - Enable verbose output
+- `--trace` - Enable tracing output
+
+## Example
+
+Deploy contract from bytecode and send 1000 function calls:
+```bash
+spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -c 1000 \
+  --contract-code "608060405234801561001057600080fd5b50..." \
+  --call-data "0xa9059cbb000000000000000000000000..."
+```
+
+Deploy contract from file and send 5 calls per slot continuously:
+```bash
+spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -t 5 \
+  --contract-file "./contract.bin" \
+  --contract-args "0x000000000000000000000000..." \
+  --call-data "0x06fdde03"
+```
+
+Deploy contract from remote URL:
+```bash
+spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -c 100 \
+  --contract-file "https://example.com/contract.bin" \
+  --call-data "0x70a08231000000000000000000000000..."
+```
+
+## ABI-Based Examples
+
+Call transfer function using ABI:
+```bash
+spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -c 1000 \
+  --contract-file "./erc20.bin" \
+  --call-abi '[{"type":"function","name":"transfer","inputs":[{"name":"to","type":"address"},{"name":"amount","type":"uint256"}]}]' \
+  --call-fn-name "transfer" \
+  --call-args '["{randomaddr}", "{random:1000000}"]'
+```
+
+Call function using signature only:
+```bash
+spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -t 5 \
+  --contract-code "608060405234801561001057600080fd5b50..." \
+  --call-fn-sig "setValue(uint256)" \
+  --call-args '["{txid}"]'
+```
+
+Complex function call with multiple argument types:
+```bash
+spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -c 500 \
+  --contract-file "./contract.bin" \
+  --call-fn-sig "complexFunction(address,uint256,bool,string)" \
+  --call-args '["{randomaddr}", "{random}", true, "test-{txid}"]'
+```
+
+Call function using ABI from local file:
+```bash
+spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -c 1000 \
+  --contract-file "./erc20.bin" \
+  --call-abi-file "./erc20-abi.json" \
+  --call-fn-name "transfer" \
+  --call-args '["{randomaddr}", "{random:1000000}"]'
+```
+
+Call function using ABI from remote URL:
+```bash
+spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -t 5 \
+  --contract-code "608060405234801561001057600080fd5b50..." \
+  --call-abi-file "https://example.com/contract-abi.json" \
+  --call-fn-name "setValue" \
+  --call-args '["{txid}"]'
+``` 

--- a/scenarios/calltx/README.md
+++ b/scenarios/calltx/README.md
@@ -22,6 +22,7 @@ spamoor calltx [flags]
 ### Contract Settings (required)
 - `--contract-code` - Contract bytecode to deploy (hex string)
 - `--contract-file` - Contract file to deploy (local file or HTTP URL)
+- `--contract-address` - Address of already deployed contract (skips deployment)
 - `--contract-args` - Constructor arguments for the contract (hex string)
 - `--call-data` - Data to pass to the function calls (hex string)
 
@@ -129,4 +130,21 @@ spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -t 5 \
   --call-abi-file "https://example.com/contract-abi.json" \
   --call-fn-name "setValue" \
   --call-args '["{txid}"]'
+```
+
+Call existing contract using address:
+```bash
+spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -c 1000 \
+  --contract-address "0x1234567890123456789012345678901234567890" \
+  --call-fn-sig "transfer(address,uint256)" \
+  --call-args '["{randomaddr}", "{random:1000000}"]'
+```
+
+Call existing contract with ABI file:
+```bash
+spamoor calltx -p "<PRIVKEY>" -h http://rpc-host:8545 -t 10 \
+  --contract-address "0xA0b86a33E6441e047c84E7c19Ff8e4Ca6c2B5B2F" \
+  --call-abi-file "./usdc-abi.json" \
+  --call-fn-name "balanceOf" \
+  --call-args '["{randomaddr}"]'
 ``` 

--- a/scenarios/calltx/calltx.go
+++ b/scenarios/calltx/calltx.go
@@ -1,0 +1,534 @@
+package erctx
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/ethpandaops/spamoor/scenariotypes"
+	"github.com/ethpandaops/spamoor/spamoor"
+	"github.com/ethpandaops/spamoor/txbuilder"
+	"github.com/ethpandaops/spamoor/utils"
+)
+
+type ScenarioOptions struct {
+	TotalCount     uint64 `yaml:"total_count"`
+	Throughput     uint64 `yaml:"throughput"`
+	MaxPending     uint64 `yaml:"max_pending"`
+	MaxWallets     uint64 `yaml:"max_wallets"`
+	Rebroadcast    uint64 `yaml:"rebroadcast"`
+	BaseFee        uint64 `yaml:"base_fee"`
+	TipFee         uint64 `yaml:"tip_fee"`
+	DeployGasLimit uint64 `yaml:"deploy_gas_limit"`
+	GasLimit       uint64 `yaml:"gas_limit"`
+	Amount         uint64 `yaml:"amount"`
+	RandomAmount   bool   `yaml:"random_amount"`
+	RandomTarget   bool   `yaml:"random_target"`
+	ContractCode   string `yaml:"contract_code"`
+	ContractFile   string `yaml:"contract_file"`
+	ContractArgs   string `yaml:"contract_args"`
+	CallData       string `yaml:"call_data"`
+	CallABI        string `yaml:"call_abi"`
+	CallABIFile    string `yaml:"call_abi_file"`
+	CallFnName     string `yaml:"call_fn_name"`
+	CallFnSig      string `yaml:"call_fn_sig"`
+	CallArgs       string `yaml:"call_args"`
+	ClientGroup    string `yaml:"client_group"`
+}
+
+type Scenario struct {
+	options    ScenarioOptions
+	logger     *logrus.Entry
+	walletPool *spamoor.WalletPool
+
+	contractAddr   common.Address
+	abiCallBuilder *utils.ABICallDataBuilder
+
+	pendingWGroup sync.WaitGroup
+}
+
+var ScenarioName = "calltx"
+var ScenarioDefaultOptions = ScenarioOptions{
+	TotalCount:     0,
+	Throughput:     0,
+	MaxPending:     0,
+	MaxWallets:     0,
+	Rebroadcast:    120,
+	BaseFee:        20,
+	TipFee:         2,
+	DeployGasLimit: 2000000,
+	GasLimit:       1000000,
+	Amount:         20,
+	RandomAmount:   false,
+	RandomTarget:   false,
+	ContractCode:   "",
+	ContractFile:   "",
+	ContractArgs:   "",
+	CallData:       "",
+	CallABI:        "",
+	CallABIFile:    "",
+	CallFnName:     "",
+	CallFnSig:      "",
+	CallArgs:       "",
+	ClientGroup:    "",
+}
+var ScenarioDescriptor = scenariotypes.ScenarioDescriptor{
+	Name:           ScenarioName,
+	Description:    "Deploy a contract and repeatedly call a function on it",
+	DefaultOptions: ScenarioDefaultOptions,
+	NewScenario:    newScenario,
+}
+
+func newScenario(logger logrus.FieldLogger) scenariotypes.Scenario {
+	return &Scenario{
+		options: ScenarioDefaultOptions,
+		logger:  logger.WithField("scenario", ScenarioName),
+	}
+}
+
+func (s *Scenario) Flags(flags *pflag.FlagSet) error {
+	flags.Uint64VarP(&s.options.TotalCount, "count", "c", ScenarioDefaultOptions.TotalCount, "Total number of call transactions to send")
+	flags.Uint64VarP(&s.options.Throughput, "throughput", "t", ScenarioDefaultOptions.Throughput, "Number of call transactions to send per slot")
+	flags.Uint64Var(&s.options.MaxPending, "max-pending", ScenarioDefaultOptions.MaxPending, "Maximum number of pending transactions")
+	flags.Uint64Var(&s.options.MaxWallets, "max-wallets", ScenarioDefaultOptions.MaxWallets, "Maximum number of child wallets to use")
+	flags.Uint64Var(&s.options.Rebroadcast, "rebroadcast", ScenarioDefaultOptions.Rebroadcast, "Number of seconds to wait before re-broadcasting a transaction")
+	flags.Uint64Var(&s.options.BaseFee, "basefee", ScenarioDefaultOptions.BaseFee, "Max fee per gas to use in call and deployment transactions (in gwei)")
+	flags.Uint64Var(&s.options.TipFee, "tipfee", ScenarioDefaultOptions.TipFee, "Max tip per gas to use in call and deployment transactions (in gwei)")
+	flags.Uint64Var(&s.options.DeployGasLimit, "deploy-gas-limit", ScenarioDefaultOptions.DeployGasLimit, "Gas limit to use for deployment transaction")
+	flags.Uint64Var(&s.options.GasLimit, "gas-limit", ScenarioDefaultOptions.GasLimit, "Gas limit to use for call transactions")
+	flags.Uint64Var(&s.options.Amount, "amount", ScenarioDefaultOptions.Amount, "Transfer amount per transaction (in gwei)")
+	flags.BoolVar(&s.options.RandomAmount, "random-amount", ScenarioDefaultOptions.RandomAmount, "Use random amounts for transactions (with --amount as limit)")
+	flags.BoolVar(&s.options.RandomTarget, "random-target", ScenarioDefaultOptions.RandomTarget, "Use random to addresses for transactions")
+	flags.StringVar(&s.options.ContractCode, "contract-code", ScenarioDefaultOptions.ContractCode, "Contract code to deploy")
+	flags.StringVar(&s.options.ContractFile, "contract-file", ScenarioDefaultOptions.ContractFile, "Contract file to deploy")
+	flags.StringVar(&s.options.ContractArgs, "contract-args", ScenarioDefaultOptions.ContractArgs, "Contract arguments to pass to the constructor")
+	flags.StringVar(&s.options.CallData, "call-data", ScenarioDefaultOptions.CallData, "Data to pass to the function to call")
+	flags.StringVar(&s.options.CallABI, "call-abi", ScenarioDefaultOptions.CallABI, "JSON ABI of the contract for function calls")
+	flags.StringVar(&s.options.CallABIFile, "call-abi-file", ScenarioDefaultOptions.CallABIFile, "JSON ABI file of the contract for function calls")
+	flags.StringVar(&s.options.CallFnName, "call-fn-name", ScenarioDefaultOptions.CallFnName, "Function name to call (requires --call-abi)")
+	flags.StringVar(&s.options.CallFnSig, "call-fn-sig", ScenarioDefaultOptions.CallFnSig, "Function signature to call (alternative to --call-abi)")
+	flags.StringVar(&s.options.CallArgs, "call-args", ScenarioDefaultOptions.CallArgs, "JSON array of arguments to pass to the function")
+	flags.StringVar(&s.options.ClientGroup, "client-group", ScenarioDefaultOptions.ClientGroup, "Client group to use for sending transactions")
+	return nil
+}
+
+func (s *Scenario) Init(options *scenariotypes.ScenarioOptions) error {
+	s.walletPool = options.WalletPool
+
+	if options.Config != "" {
+		err := yaml.Unmarshal([]byte(options.Config), &s.options)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal config: %w", err)
+		}
+	}
+
+	if s.options.MaxWallets > 0 {
+		s.walletPool.SetWalletCount(s.options.MaxWallets)
+	} else if s.options.TotalCount > 0 {
+		if s.options.TotalCount < 1000 {
+			s.walletPool.SetWalletCount(s.options.TotalCount)
+		} else {
+			s.walletPool.SetWalletCount(1000)
+		}
+	} else {
+		if s.options.Throughput*10 < 1000 {
+			s.walletPool.SetWalletCount(s.options.Throughput * 10)
+		} else {
+			s.walletPool.SetWalletCount(1000)
+		}
+	}
+
+	if s.options.TotalCount == 0 && s.options.Throughput == 0 {
+		return fmt.Errorf("neither total count nor throughput limit set, must define at least one of them (see --help for list of all flags)")
+	}
+
+	if s.options.ContractCode == "" && s.options.ContractFile == "" {
+		return fmt.Errorf("either contract code or contract file must be set")
+	}
+	if s.options.ContractCode != "" && s.options.ContractFile != "" {
+		return fmt.Errorf("only one of contract code or contract file can be set")
+	}
+
+	// Initialize ABI call builder if ABI options are provided
+	if s.options.CallABI != "" || s.options.CallABIFile != "" || s.options.CallFnSig != "" {
+		var abiContent string
+		var err error
+
+		// Load ABI content from file if specified
+		if s.options.CallABIFile != "" {
+			if s.options.CallABI != "" {
+				return fmt.Errorf("only one of --call-abi or --call-abi-file can be set")
+			}
+
+			var abiBytes []byte
+			if strings.HasPrefix(s.options.CallABIFile, "https://") || strings.HasPrefix(s.options.CallABIFile, "http://") {
+				resp, err := http.Get(s.options.CallABIFile)
+				if err != nil {
+					return fmt.Errorf("could not load ABI file: %w", err)
+				}
+				defer resp.Body.Close()
+				abiBytes, err = io.ReadAll(resp.Body)
+				if err != nil {
+					return fmt.Errorf("could not read ABI file: %w", err)
+				}
+			} else {
+				abiBytes, err = os.ReadFile(s.options.CallABIFile)
+				if err != nil {
+					return fmt.Errorf("could not read ABI file: %w", err)
+				}
+			}
+			abiContent = string(abiBytes)
+		} else {
+			abiContent = s.options.CallABI
+		}
+
+		s.abiCallBuilder, err = utils.NewABICallDataBuilder(abiContent, s.options.CallFnName, s.options.CallFnSig, s.options.CallArgs)
+		if err != nil {
+			return fmt.Errorf("failed to initialize ABI call builder: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Scenario) Config() string {
+	yamlBytes, _ := yaml.Marshal(&s.options)
+	return string(yamlBytes)
+}
+
+func (s *Scenario) Run(ctx context.Context) error {
+	s.logger.Infof("starting scenario: %s", ScenarioName)
+	defer s.logger.Infof("scenario %s finished.", ScenarioName)
+
+	// load contract
+	var contractCode []byte
+	if s.options.ContractCode != "" {
+		contractCode = common.FromHex(s.options.ContractCode)
+	} else if strings.HasPrefix(s.options.ContractFile, "https://") || strings.HasPrefix(s.options.ContractFile, "http://") {
+		resp, err := http.Get(s.options.ContractFile)
+		if err != nil {
+			return fmt.Errorf("could not load contract file: %w", err)
+		}
+		defer resp.Body.Close()
+		contractCode, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("could not read contract file: %w", err)
+		}
+	} else {
+		code, err := os.ReadFile(s.options.ContractFile)
+		if err != nil {
+			return fmt.Errorf("could not read contract file: %w", err)
+		}
+		contractCode = code
+	}
+
+	// deploy contract
+	contractReceipt, _, err := s.sendDeploymentTx(ctx, contractCode)
+	if err != nil {
+		s.logger.Errorf("could not deploy contract: %v", err)
+		return err
+	}
+	if contractReceipt == nil {
+		return fmt.Errorf("could not deploy contract: %w", err)
+	}
+	s.contractAddr = contractReceipt.ContractAddress
+	s.logger.Infof("deployed contract: %v (confirmed in block #%v)", s.contractAddr.String(), contractReceipt.BlockNumber.String())
+
+	// send transactions
+	maxPending := s.options.MaxPending
+	if maxPending == 0 {
+		maxPending = s.options.Throughput * 10
+		if maxPending == 0 {
+			maxPending = 4000
+		}
+
+		if maxPending > s.walletPool.GetConfiguredWalletCount()*10 {
+			maxPending = s.walletPool.GetConfiguredWalletCount() * 10
+		}
+	}
+
+	err = utils.RunTransactionScenario(ctx, utils.TransactionScenarioOptions{
+		TotalCount:                  s.options.TotalCount,
+		Throughput:                  s.options.Throughput,
+		MaxPending:                  maxPending,
+		ThroughputIncrementInterval: 0,
+
+		Logger: s.logger,
+		ProcessNextTxFn: func(ctx context.Context, txIdx uint64, onComplete func()) (func(), error) {
+			logger := s.logger
+			tx, client, wallet, err := s.sendTx(ctx, txIdx, onComplete)
+			if client != nil {
+				logger = logger.WithField("rpc", client.GetName())
+			}
+			if tx != nil {
+				logger = logger.WithField("nonce", tx.Nonce())
+			}
+			if wallet != nil {
+				logger = logger.WithField("wallet", s.walletPool.GetWalletName(wallet.GetAddress()))
+			}
+
+			return func() {
+				if err != nil {
+					logger.Warnf("could not send transaction: %v", err)
+				} else {
+					logger.Infof("sent tx #%6d: %v", txIdx+1, tx.Hash().String())
+				}
+			}, err
+		},
+	})
+
+	s.logger.Infof("finished sending transactions, awaiting block inclusion...")
+	s.pendingWGroup.Wait()
+
+	return err
+}
+
+func (s *Scenario) sendDeploymentTx(ctx context.Context, contractCode []byte) (*types.Receipt, *spamoor.Client, error) {
+	client := s.walletPool.GetClient(spamoor.SelectClientByIndex, 0, s.options.ClientGroup)
+	wallet := s.walletPool.GetWallet(spamoor.SelectWalletByIndex, 0)
+
+	var feeCap *big.Int
+	var tipCap *big.Int
+
+	if client == nil {
+		return nil, client, fmt.Errorf("no client available")
+	}
+
+	if s.options.BaseFee > 0 {
+		feeCap = new(big.Int).Mul(big.NewInt(int64(s.options.BaseFee)), big.NewInt(1000000000))
+	}
+	if s.options.TipFee > 0 {
+		tipCap = new(big.Int).Mul(big.NewInt(int64(s.options.TipFee)), big.NewInt(1000000000))
+	}
+
+	if feeCap == nil || tipCap == nil {
+		var err error
+		feeCap, tipCap, err = client.GetSuggestedFee(s.walletPool.GetContext())
+		if err != nil {
+			return nil, client, err
+		}
+	}
+
+	if feeCap.Cmp(big.NewInt(1000000000)) < 0 {
+		feeCap = big.NewInt(1000000000)
+	}
+	if tipCap.Cmp(big.NewInt(1000000000)) < 0 {
+		tipCap = big.NewInt(1000000000)
+	}
+
+	deployData := contractCode
+	if s.options.ContractArgs != "" {
+		deployData = append(deployData, common.FromHex(s.options.ContractArgs)...)
+	}
+
+	txData, err := txbuilder.DynFeeTx(&txbuilder.TxMetadata{
+		GasFeeCap: uint256.MustFromBig(feeCap),
+		GasTipCap: uint256.MustFromBig(tipCap),
+		Gas:       s.options.GasLimit,
+		To:        nil,
+		Value:     uint256.NewInt(0),
+		Data:      deployData,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tx, err := wallet.BuildDynamicFeeTx(txData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var txReceipt *types.Receipt
+	var txErr error
+	txWg := sync.WaitGroup{}
+	txWg.Add(1)
+
+	err = s.walletPool.GetTxPool().SendTransaction(ctx, wallet, tx, &spamoor.SendTransactionOptions{
+		Client:              client,
+		MaxRebroadcasts:     10,
+		RebroadcastInterval: 30 * time.Second,
+		OnConfirm: func(tx *types.Transaction, receipt *types.Receipt, err error) {
+			defer func() {
+				txWg.Done()
+			}()
+
+			txErr = err
+			txReceipt = receipt
+		},
+	})
+	if err != nil {
+		return nil, client, err
+	}
+
+	txWg.Wait()
+	if txErr != nil {
+		return nil, client, err
+	}
+	return txReceipt, client, nil
+}
+
+func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) (*types.Transaction, *spamoor.Client, *spamoor.Wallet, error) {
+	client := s.walletPool.GetClient(spamoor.SelectClientByIndex, int(txIdx), s.options.ClientGroup)
+	wallet := s.walletPool.GetWallet(spamoor.SelectWalletByIndex, int(txIdx))
+	transactionSubmitted := false
+
+	defer func() {
+		if !transactionSubmitted {
+			onComplete()
+		}
+	}()
+
+	if client == nil {
+		return nil, client, wallet, fmt.Errorf("no client available")
+	}
+
+	var feeCap *big.Int
+	var tipCap *big.Int
+
+	if s.options.BaseFee > 0 {
+		feeCap = new(big.Int).Mul(big.NewInt(int64(s.options.BaseFee)), big.NewInt(1000000000))
+	}
+	if s.options.TipFee > 0 {
+		tipCap = new(big.Int).Mul(big.NewInt(int64(s.options.TipFee)), big.NewInt(1000000000))
+	}
+
+	if feeCap == nil || tipCap == nil {
+		var err error
+		feeCap, tipCap, err = client.GetSuggestedFee(s.walletPool.GetContext())
+		if err != nil {
+			return nil, client, wallet, err
+		}
+	}
+
+	if feeCap.Cmp(big.NewInt(1000000000)) < 0 {
+		feeCap = big.NewInt(1000000000)
+	}
+	if tipCap.Cmp(big.NewInt(1000000000)) < 0 {
+		tipCap = big.NewInt(1000000000)
+	}
+
+	amount := uint256.NewInt(s.options.Amount)
+	amount = amount.Mul(amount, uint256.NewInt(1000000000))
+	if s.options.RandomAmount {
+		n, err := rand.Int(rand.Reader, amount.ToBig())
+		if err == nil {
+			amount = uint256.MustFromBig(n)
+		}
+	}
+
+	txCallData := []byte{}
+
+	if s.abiCallBuilder != nil {
+		// Use ABI call builder
+		var err error
+		txCallData, err = s.abiCallBuilder.BuildCallData(txIdx)
+		if err != nil {
+			return nil, nil, wallet, fmt.Errorf("failed to build ABI call data: %w", err)
+		}
+	} else if s.options.CallData != "" {
+		// Use raw call data
+		dataBytes, err := txbuilder.ParseBlobRefsBytes(strings.Split(s.options.CallData, ","), nil)
+		if err != nil {
+			return nil, nil, wallet, err
+		}
+		txCallData = dataBytes
+	}
+
+	txData, err := txbuilder.DynFeeTx(&txbuilder.TxMetadata{
+		GasFeeCap: uint256.MustFromBig(feeCap),
+		GasTipCap: uint256.MustFromBig(tipCap),
+		Gas:       s.options.GasLimit,
+		To:        &s.contractAddr,
+		Value:     amount,
+		Data:      txCallData,
+	})
+	if err != nil {
+		return nil, nil, wallet, err
+	}
+
+	tx, err := wallet.BuildDynamicFeeTx(txData)
+	if err != nil {
+		return nil, nil, wallet, err
+	}
+
+	rebroadcast := 0
+	if s.options.Rebroadcast > 0 {
+		rebroadcast = 10
+	}
+
+	s.pendingWGroup.Add(1)
+	transactionSubmitted = true
+	err = s.walletPool.GetTxPool().SendTransaction(ctx, wallet, tx, &spamoor.SendTransactionOptions{
+		Client:              client,
+		MaxRebroadcasts:     rebroadcast,
+		RebroadcastInterval: time.Duration(s.options.Rebroadcast) * time.Second,
+		OnConfirm: func(tx *types.Transaction, receipt *types.Receipt, err error) {
+			defer func() {
+				onComplete()
+				s.pendingWGroup.Done()
+			}()
+
+			if err != nil {
+				s.logger.WithField("rpc", client.GetName()).Warnf("tx %6d: await receipt failed: %v", txIdx+1, err)
+				return
+			}
+			if receipt == nil {
+				return
+			}
+
+			effectiveGasPrice := receipt.EffectiveGasPrice
+			if effectiveGasPrice == nil {
+				effectiveGasPrice = big.NewInt(0)
+			}
+			feeAmount := new(big.Int).Mul(effectiveGasPrice, big.NewInt(int64(receipt.GasUsed)))
+			totalAmount := new(big.Int).Add(tx.Value(), feeAmount)
+			wallet.SubBalance(totalAmount)
+
+			gweiTotalFee := new(big.Int).Div(feeAmount, big.NewInt(1000000000))
+			gweiBaseFee := new(big.Int).Div(effectiveGasPrice, big.NewInt(1000000000))
+
+			s.logger.WithField("rpc", client.GetName()).Debugf(" transaction %d confirmed in block #%v. total fee: %v gwei (base: %v) logs: %v", txIdx+1, receipt.BlockNumber.String(), gweiTotalFee, gweiBaseFee, len(receipt.Logs))
+		},
+		LogFn: func(client *spamoor.Client, retry int, rebroadcast int, err error) {
+			logger := s.logger.WithField("rpc", client.GetName())
+			if retry > 0 {
+				logger = logger.WithField("retry", retry)
+			}
+			if rebroadcast > 0 {
+				logger = logger.WithField("rebroadcast", rebroadcast)
+			}
+			if err != nil {
+				logger.Debugf("failed sending tx %6d: %v", txIdx+1, err)
+			} else if retry > 0 || rebroadcast > 0 {
+				logger.Debugf("successfully sent tx %6d", txIdx+1)
+			}
+		},
+	})
+	if err != nil {
+		// reset nonce if tx was not sent
+		wallet.ResetPendingNonce(ctx, client)
+
+		return nil, client, wallet, err
+	}
+
+	return tx, client, wallet, nil
+}

--- a/scenarios/calltx/calltx.go
+++ b/scenarios/calltx/calltx.go
@@ -1,4 +1,4 @@
-package erctx
+package calltx
 
 import (
 	"context"
@@ -74,7 +74,7 @@ var ScenarioDefaultOptions = ScenarioOptions{
 	TipFee:          2,
 	DeployGasLimit:  2000000,
 	GasLimit:        1000000,
-	Amount:          20,
+	Amount:          0,
 	RandomAmount:    false,
 	RandomTarget:    false,
 	ContractCode:    "",
@@ -248,16 +248,17 @@ func (s *Scenario) Run(ctx context.Context) error {
 				return fmt.Errorf("could not load contract file: %w", err)
 			}
 			defer resp.Body.Close()
-			contractCode, err = io.ReadAll(resp.Body)
+			contractCodeHex, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return fmt.Errorf("could not read contract file: %w", err)
 			}
+			contractCode = common.FromHex(strings.Trim(string(contractCodeHex), "\r\n\t "))
 		} else {
 			code, err := os.ReadFile(s.options.ContractFile)
 			if err != nil {
 				return fmt.Errorf("could not read contract file: %w", err)
 			}
-			contractCode = code
+			contractCode = common.FromHex(strings.Trim(string(code), "\r\n\t "))
 		}
 
 		// deploy contract

--- a/scenarios/scenarios.go
+++ b/scenarios/scenarios.go
@@ -7,6 +7,7 @@ import (
 	blobconflicting "github.com/ethpandaops/spamoor/scenarios/blob-conflicting"
 	blobreplacements "github.com/ethpandaops/spamoor/scenarios/blob-replacements"
 	"github.com/ethpandaops/spamoor/scenarios/blobs"
+	"github.com/ethpandaops/spamoor/scenarios/calltx"
 	deploydestruct "github.com/ethpandaops/spamoor/scenarios/deploy-destruct"
 	"github.com/ethpandaops/spamoor/scenarios/deploytx"
 	"github.com/ethpandaops/spamoor/scenarios/eoatx"
@@ -24,6 +25,7 @@ var ScenarioDescriptors = []*scenariotypes.ScenarioDescriptor{
 	&blobconflicting.ScenarioDescriptor,
 	&blobs.ScenarioDescriptor,
 	&blobreplacements.ScenarioDescriptor,
+	&calltx.ScenarioDescriptor,
 	&deploydestruct.ScenarioDescriptor,
 	&deploytx.ScenarioDescriptor,
 	&eoatx.ScenarioDescriptor,

--- a/utils/abi.go
+++ b/utils/abi.go
@@ -1,0 +1,684 @@
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type ABICallDataBuilder struct {
+	contractABI    *abi.ABI
+	functionName   string
+	functionSig    string
+	callArgs       string
+	parsedFunction *abi.Method
+}
+
+func NewABICallDataBuilder(callABI, callFnName, callFnSig, callArgs string) (*ABICallDataBuilder, error) {
+	builder := &ABICallDataBuilder{
+		functionName: callFnName,
+		functionSig:  callFnSig,
+		callArgs:     callArgs,
+	}
+
+	// Parse ABI if provided
+	if callABI != "" {
+		contractABI, err := abi.JSON(strings.NewReader(callABI))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse contract ABI: %w", err)
+		}
+		builder.contractABI = &contractABI
+	}
+
+	// Parse function
+	if err := builder.parseFunction(); err != nil {
+		return nil, err
+	}
+
+	return builder, nil
+}
+
+func (b *ABICallDataBuilder) parseFunction() error {
+	if b.contractABI != nil && b.functionName != "" {
+		// Use ABI + function name
+		method, exists := b.contractABI.Methods[b.functionName]
+		if !exists {
+			return fmt.Errorf("function %s not found in ABI", b.functionName)
+		}
+		b.parsedFunction = &method
+	} else if b.functionSig != "" {
+		// Parse function signature directly
+		functionABI, err := parseFunctionSignature(b.functionSig)
+		if err != nil {
+			return fmt.Errorf("failed to parse function signature: %w", err)
+		}
+
+		parsedABI, err := abi.JSON(strings.NewReader(fmt.Sprintf("[%s]", functionABI)))
+		if err != nil {
+			return fmt.Errorf("failed to parse constructed ABI: %w", err)
+		}
+
+		// Get the function from the parsed ABI
+		for _, method := range parsedABI.Methods {
+			b.parsedFunction = &method
+			break
+		}
+	} else {
+		return fmt.Errorf("either call-abi+call-fn-name or call-fn-signature must be provided")
+	}
+
+	return nil
+}
+
+// parseFunctionSignature parses a function signature like "transfer(address,uint256)"
+// and returns the corresponding ABI JSON string
+func parseFunctionSignature(signature string) (string, error) {
+	// Remove any whitespace
+	signature = strings.ReplaceAll(signature, " ", "")
+
+	// Find the opening parenthesis
+	parenIndex := strings.Index(signature, "(")
+	if parenIndex == -1 {
+		return "", fmt.Errorf("invalid function signature: missing opening parenthesis")
+	}
+
+	functionName := signature[:parenIndex]
+	if functionName == "" {
+		return "", fmt.Errorf("invalid function signature: missing function name")
+	}
+
+	// Extract the parameters part
+	if !strings.HasSuffix(signature, ")") {
+		return "", fmt.Errorf("invalid function signature: missing closing parenthesis")
+	}
+
+	paramsPart := signature[parenIndex+1 : len(signature)-1]
+
+	// Parse parameters
+	var inputs []string
+	if paramsPart != "" {
+		paramTypes := strings.Split(paramsPart, ",")
+		for i, paramType := range paramTypes {
+			paramType = strings.TrimSpace(paramType)
+			if paramType == "" {
+				return "", fmt.Errorf("invalid function signature: empty parameter type at position %d", i)
+			}
+
+			// Validate the parameter type
+			if err := validateSolidityType(paramType); err != nil {
+				return "", fmt.Errorf("invalid parameter type '%s': %w", paramType, err)
+			}
+
+			inputs = append(inputs, fmt.Sprintf(`{"name":"param%d","type":"%s"}`, i, paramType))
+		}
+	}
+
+	// Construct ABI JSON
+	abiJSON := fmt.Sprintf(`{
+		"type": "function",
+		"name": "%s",
+		"inputs": [%s],
+		"outputs": [],
+		"stateMutability": "payable"
+	}`, functionName, strings.Join(inputs, ","))
+
+	return abiJSON, nil
+}
+
+// validateSolidityType validates if a string is a valid Solidity type
+func validateSolidityType(typeName string) error {
+	// Basic types
+	basicTypes := map[string]bool{
+		"address": true, "bool": true, "string": true, "bytes": true,
+	}
+
+	if basicTypes[typeName] {
+		return nil
+	}
+
+	// Check uint types (uint8, uint16, ..., uint256)
+	if strings.HasPrefix(typeName, "uint") {
+		suffix := typeName[4:]
+		if suffix == "" {
+			return nil // uint is valid (defaults to uint256)
+		}
+		size, err := strconv.Atoi(suffix)
+		if err != nil || size < 8 || size > 256 || size%8 != 0 {
+			return fmt.Errorf("invalid uint size: must be between 8 and 256 and divisible by 8")
+		}
+		return nil
+	}
+
+	// Check int types (int8, int16, ..., int256)
+	if strings.HasPrefix(typeName, "int") {
+		suffix := typeName[3:]
+		if suffix == "" {
+			return nil // int is valid (defaults to int256)
+		}
+		size, err := strconv.Atoi(suffix)
+		if err != nil || size < 8 || size > 256 || size%8 != 0 {
+			return fmt.Errorf("invalid int size: must be between 8 and 256 and divisible by 8")
+		}
+		return nil
+	}
+
+	// Check fixed bytes types (bytes1, bytes2, ..., bytes32)
+	if strings.HasPrefix(typeName, "bytes") {
+		suffix := typeName[5:]
+		if suffix == "" {
+			return nil // bytes is valid (dynamic bytes)
+		}
+		size, err := strconv.Atoi(suffix)
+		if err != nil || size < 1 || size > 32 {
+			return fmt.Errorf("invalid fixed bytes size: must be between 1 and 32")
+		}
+		return nil
+	}
+
+	// Check array types
+	if strings.HasSuffix(typeName, "[]") {
+		baseType := typeName[:len(typeName)-2]
+		return validateSolidityType(baseType)
+	}
+
+	// Check fixed array types like uint256[10]
+	if strings.Contains(typeName, "[") && strings.HasSuffix(typeName, "]") {
+		bracketIndex := strings.LastIndex(typeName, "[")
+		baseType := typeName[:bracketIndex]
+		sizeStr := typeName[bracketIndex+1 : len(typeName)-1]
+
+		if sizeStr == "" {
+			return fmt.Errorf("invalid array type: missing size")
+		}
+
+		size, err := strconv.Atoi(sizeStr)
+		if err != nil || size <= 0 {
+			return fmt.Errorf("invalid array size: must be positive integer")
+		}
+
+		return validateSolidityType(baseType)
+	}
+
+	return fmt.Errorf("unknown type '%s'", typeName)
+}
+
+func (b *ABICallDataBuilder) BuildCallData(txIdx uint64) ([]byte, error) {
+	if b.parsedFunction == nil {
+		return nil, fmt.Errorf("function not parsed")
+	}
+
+	// Parse and substitute placeholders in args
+	processedArgs, err := b.processArgs(b.callArgs, txIdx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process args: %w", err)
+	}
+
+	// Parse JSON args
+	var argValues []interface{}
+	if processedArgs != "" && processedArgs != "[]" {
+		if err := json.Unmarshal([]byte(processedArgs), &argValues); err != nil {
+			return nil, fmt.Errorf("failed to parse call args as JSON: %w", err)
+		}
+	}
+
+	// Validate arguments against ABI
+	if err := b.validateArgs(argValues); err != nil {
+		return nil, fmt.Errorf("argument validation failed: %w", err)
+	}
+
+	// Convert args to proper types
+	convertedArgs, err := b.convertArgs(argValues)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert args: %w", err)
+	}
+
+	// Pack the function call
+	callData, err := b.parsedFunction.Inputs.Pack(convertedArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack function arguments: %w", err)
+	}
+
+	// Prepend function selector
+	fullCallData := append(b.parsedFunction.ID, callData...)
+	return fullCallData, nil
+}
+
+func (b *ABICallDataBuilder) processArgs(args string, txIdx uint64) (string, error) {
+	if args == "" {
+		return "[]", nil
+	}
+
+	// Replace placeholders
+	processed := args
+
+	// Replace {txid} with transaction index
+	processed = strings.ReplaceAll(processed, "{txid}", fmt.Sprintf("%d", txIdx))
+
+	// Replace {random} with random uint256
+	randomRegex := regexp.MustCompile(`\{random\}`)
+	randomMatches := randomRegex.FindAllStringSubmatch(processed, -1)
+	for _, match := range randomMatches {
+		randomVal, err := generateRandomUint256()
+		if err != nil {
+			return "", fmt.Errorf("failed to generate random value: %w", err)
+		}
+		processed = strings.Replace(processed, match[0], randomVal, 1)
+	}
+
+	// Replace {random:N} with random number between 0 and N
+	randomRangeRegex := regexp.MustCompile(`\{random:(\d+)\}`)
+	randomRangeMatches := randomRangeRegex.FindAllStringSubmatch(processed, -1)
+	for _, match := range randomRangeMatches {
+		if len(match) != 2 {
+			continue
+		}
+		maxVal, err := strconv.ParseUint(match[1], 10, 64)
+		if err != nil {
+			return "", fmt.Errorf("invalid random range: %s", match[1])
+		}
+		randomVal, err := generateRandomInRange(maxVal)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate random value in range: %w", err)
+		}
+		processed = strings.Replace(processed, match[0], fmt.Sprintf("%d", randomVal), 1)
+	}
+
+	// Replace {randomaddr} with random address
+	randomAddrRegex := regexp.MustCompile(`\{randomaddr\}`)
+	randomAddrMatches := randomAddrRegex.FindAllStringSubmatch(processed, -1)
+	for _, match := range randomAddrMatches {
+		randomAddr, err := generateRandomAddress()
+		if err != nil {
+			return "", fmt.Errorf("failed to generate random address: %w", err)
+		}
+		processed = strings.Replace(processed, match[0], randomAddr, 1)
+	}
+
+	return processed, nil
+}
+
+func (b *ABICallDataBuilder) convertArgs(args []interface{}) ([]interface{}, error) {
+	if len(args) != len(b.parsedFunction.Inputs) {
+		return nil, fmt.Errorf("expected %d arguments, got %d", len(b.parsedFunction.Inputs), len(args))
+	}
+
+	converted := make([]interface{}, len(args))
+	for i, arg := range args {
+		expectedType := b.parsedFunction.Inputs[i].Type
+		convertedArg, err := convertArgument(arg, expectedType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert argument %d: %w", i, err)
+		}
+		converted[i] = convertedArg
+	}
+
+	return converted, nil
+}
+
+func convertArgument(arg interface{}, expectedType abi.Type) (interface{}, error) {
+	switch expectedType.T {
+	case abi.UintTy:
+		return convertToUint(arg, expectedType.Size)
+	case abi.IntTy:
+		return convertToInt(arg, expectedType.Size)
+	case abi.AddressTy:
+		return convertToAddress(arg)
+	case abi.BoolTy:
+		return convertToBool(arg)
+	case abi.StringTy:
+		return convertToString(arg)
+	case abi.BytesTy:
+		return convertToBytes(arg)
+	case abi.FixedBytesTy:
+		return convertToFixedBytes(arg, expectedType.Size)
+	case abi.SliceTy:
+		return convertToSlice(arg, expectedType)
+	default:
+		return nil, fmt.Errorf("unsupported type: %s", expectedType.String())
+	}
+}
+
+func convertToUint(arg interface{}, size int) (*big.Int, error) {
+	switch v := arg.(type) {
+	case string:
+		if strings.HasPrefix(v, "0x") {
+			result, ok := new(big.Int).SetString(v[2:], 16)
+			if !ok {
+				return nil, fmt.Errorf("invalid hex number: %s", v)
+			}
+			return result, nil
+		}
+		result, ok := new(big.Int).SetString(v, 10)
+		if !ok {
+			return nil, fmt.Errorf("invalid number: %s", v)
+		}
+		return result, nil
+	case float64:
+		return big.NewInt(int64(v)), nil
+	case int:
+		return big.NewInt(int64(v)), nil
+	default:
+		return nil, fmt.Errorf("cannot convert %T to uint%d", arg, size*8)
+	}
+}
+
+func convertToInt(arg interface{}, size int) (*big.Int, error) {
+	return convertToUint(arg, size) // Same conversion logic
+}
+
+func convertToAddress(arg interface{}) (common.Address, error) {
+	switch v := arg.(type) {
+	case string:
+		if !common.IsHexAddress(v) {
+			return common.Address{}, fmt.Errorf("invalid address format: %s", v)
+		}
+		return common.HexToAddress(v), nil
+	default:
+		return common.Address{}, fmt.Errorf("cannot convert %T to address", arg)
+	}
+}
+
+func convertToBool(arg interface{}) (bool, error) {
+	switch v := arg.(type) {
+	case bool:
+		return v, nil
+	case string:
+		return strconv.ParseBool(v)
+	default:
+		return false, fmt.Errorf("cannot convert %T to bool", arg)
+	}
+}
+
+func convertToString(arg interface{}) (string, error) {
+	switch v := arg.(type) {
+	case string:
+		return v, nil
+	default:
+		return fmt.Sprintf("%v", arg), nil
+	}
+}
+
+func convertToBytes(arg interface{}) ([]byte, error) {
+	switch v := arg.(type) {
+	case string:
+		if strings.HasPrefix(v, "0x") {
+			return common.FromHex(v), nil
+		}
+		return []byte(v), nil
+	default:
+		return nil, fmt.Errorf("cannot convert %T to bytes", arg)
+	}
+}
+
+func convertToFixedBytes(arg interface{}, size int) (interface{}, error) {
+	bytes, err := convertToBytes(arg)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(bytes) > size {
+		return nil, fmt.Errorf("bytes too long for fixed bytes%d", size)
+	}
+
+	// Pad to the right size
+	padded := make([]byte, size)
+	copy(padded, bytes)
+
+	// Return as fixed-size array
+	switch size {
+	case 32:
+		var result [32]byte
+		copy(result[:], padded)
+		return result, nil
+	default:
+		return padded, nil
+	}
+}
+
+func convertToSlice(arg interface{}, expectedType abi.Type) (interface{}, error) {
+	slice, ok := arg.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected array/slice for %s", expectedType.String())
+	}
+
+	converted := make([]interface{}, len(slice))
+	for i, elem := range slice {
+		convertedElem, err := convertArgument(elem, *expectedType.Elem)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert slice element %d: %w", i, err)
+		}
+		converted[i] = convertedElem
+	}
+
+	return converted, nil
+}
+
+func generateRandomUint256() (string, error) {
+	bytes := make([]byte, 32)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return "", err
+	}
+	return new(big.Int).SetBytes(bytes).String(), nil
+}
+
+func generateRandomInRange(max uint64) (uint64, error) {
+	if max == 0 {
+		return 0, nil
+	}
+	bytes := make([]byte, 8)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return 0, err
+	}
+	randomVal := new(big.Int).SetBytes(bytes).Uint64()
+	return randomVal % max, nil
+}
+
+func generateRandomAddress() (string, error) {
+	bytes := make([]byte, 20)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return "", err
+	}
+	return common.BytesToAddress(bytes).Hex(), nil
+}
+
+// validateArgs validates that the provided arguments are compatible with the function signature
+func (b *ABICallDataBuilder) validateArgs(args []interface{}) error {
+	expectedCount := len(b.parsedFunction.Inputs)
+	actualCount := len(args)
+
+	if actualCount != expectedCount {
+		return fmt.Errorf("function %s expects %d arguments, got %d",
+			b.parsedFunction.Name, expectedCount, actualCount)
+	}
+
+	// Validate each argument against its expected type
+	for i, arg := range args {
+		expectedType := b.parsedFunction.Inputs[i].Type
+		paramName := b.parsedFunction.Inputs[i].Name
+		if paramName == "" {
+			paramName = fmt.Sprintf("param%d", i)
+		}
+
+		if err := b.validateArgType(arg, expectedType, paramName, i); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateArgType validates a single argument against its expected ABI type
+func (b *ABICallDataBuilder) validateArgType(arg interface{}, expectedType abi.Type, paramName string, paramIndex int) error {
+	switch expectedType.T {
+	case abi.UintTy, abi.IntTy:
+		return b.validateIntegerArg(arg, expectedType, paramName, paramIndex)
+	case abi.AddressTy:
+		return b.validateAddressArg(arg, paramName, paramIndex)
+	case abi.BoolTy:
+		return b.validateBoolArg(arg, paramName, paramIndex)
+	case abi.StringTy:
+		return b.validateStringArg(arg, paramName, paramIndex)
+	case abi.BytesTy:
+		return b.validateBytesArg(arg, paramName, paramIndex)
+	case abi.FixedBytesTy:
+		return b.validateFixedBytesArg(arg, expectedType, paramName, paramIndex)
+	case abi.SliceTy:
+		return b.validateSliceArg(arg, expectedType, paramName, paramIndex)
+	case abi.ArrayTy:
+		return b.validateArrayArg(arg, expectedType, paramName, paramIndex)
+	default:
+		return fmt.Errorf("parameter %s (index %d): unsupported type %s", paramName, paramIndex, expectedType.String())
+	}
+}
+
+func (b *ABICallDataBuilder) validateIntegerArg(arg interface{}, expectedType abi.Type, paramName string, paramIndex int) error {
+	switch v := arg.(type) {
+	case string:
+		if v == "" {
+			return fmt.Errorf("parameter %s (index %d): empty string not valid for %s", paramName, paramIndex, expectedType.String())
+		}
+		// Try to parse as number to validate format
+		if strings.HasPrefix(v, "0x") {
+			if _, ok := new(big.Int).SetString(v[2:], 16); !ok {
+				return fmt.Errorf("parameter %s (index %d): invalid hex number format '%s'", paramName, paramIndex, v)
+			}
+		} else {
+			if _, ok := new(big.Int).SetString(v, 10); !ok {
+				return fmt.Errorf("parameter %s (index %d): invalid number format '%s'", paramName, paramIndex, v)
+			}
+		}
+	case float64:
+		if v < 0 && expectedType.T == abi.UintTy {
+			return fmt.Errorf("parameter %s (index %d): negative number not valid for %s", paramName, paramIndex, expectedType.String())
+		}
+	case int:
+		if v < 0 && expectedType.T == abi.UintTy {
+			return fmt.Errorf("parameter %s (index %d): negative number not valid for %s", paramName, paramIndex, expectedType.String())
+		}
+	default:
+		return fmt.Errorf("parameter %s (index %d): expected string or number for %s, got %T", paramName, paramIndex, expectedType.String(), arg)
+	}
+	return nil
+}
+
+func (b *ABICallDataBuilder) validateAddressArg(arg interface{}, paramName string, paramIndex int) error {
+	switch v := arg.(type) {
+	case string:
+		if v == "" {
+			return fmt.Errorf("parameter %s (index %d): empty string not valid for address", paramName, paramIndex)
+		}
+		if !common.IsHexAddress(v) {
+			return fmt.Errorf("parameter %s (index %d): invalid address format '%s'", paramName, paramIndex, v)
+		}
+	default:
+		return fmt.Errorf("parameter %s (index %d): expected string for address, got %T", paramName, paramIndex, arg)
+	}
+	return nil
+}
+
+func (b *ABICallDataBuilder) validateBoolArg(arg interface{}, paramName string, paramIndex int) error {
+	switch v := arg.(type) {
+	case bool:
+		// Valid
+	case string:
+		if _, err := strconv.ParseBool(v); err != nil {
+			return fmt.Errorf("parameter %s (index %d): invalid bool format '%s'", paramName, paramIndex, v)
+		}
+	default:
+		return fmt.Errorf("parameter %s (index %d): expected bool or string for bool, got %T", paramName, paramIndex, arg)
+	}
+	return nil
+}
+
+func (b *ABICallDataBuilder) validateStringArg(arg interface{}, paramName string, paramIndex int) error {
+	// Almost anything can be converted to string, so this is quite permissive
+	return nil
+}
+
+func (b *ABICallDataBuilder) validateBytesArg(arg interface{}, paramName string, paramIndex int) error {
+	switch v := arg.(type) {
+	case string:
+		if strings.HasPrefix(v, "0x") {
+			if len(v)%2 != 0 {
+				return fmt.Errorf("parameter %s (index %d): hex string must have even length", paramName, paramIndex)
+			}
+		}
+		// Non-hex strings are valid (will be converted to bytes)
+	default:
+		return fmt.Errorf("parameter %s (index %d): expected string for bytes, got %T", paramName, paramIndex, arg)
+	}
+	return nil
+}
+
+func (b *ABICallDataBuilder) validateFixedBytesArg(arg interface{}, expectedType abi.Type, paramName string, paramIndex int) error {
+	switch v := arg.(type) {
+	case string:
+		var bytes []byte
+		if strings.HasPrefix(v, "0x") {
+			if len(v)%2 != 0 {
+				return fmt.Errorf("parameter %s (index %d): hex string must have even length", paramName, paramIndex)
+			}
+			bytes = common.FromHex(v)
+		} else {
+			bytes = []byte(v)
+		}
+
+		if len(bytes) > expectedType.Size {
+			return fmt.Errorf("parameter %s (index %d): bytes too long for %s (max %d bytes, got %d)",
+				paramName, paramIndex, expectedType.String(), expectedType.Size, len(bytes))
+		}
+	default:
+		return fmt.Errorf("parameter %s (index %d): expected string for %s, got %T", paramName, paramIndex, expectedType.String(), arg)
+	}
+	return nil
+}
+
+func (b *ABICallDataBuilder) validateSliceArg(arg interface{}, expectedType abi.Type, paramName string, paramIndex int) error {
+	slice, ok := arg.([]interface{})
+	if !ok {
+		return fmt.Errorf("parameter %s (index %d): expected array for %s, got %T", paramName, paramIndex, expectedType.String(), arg)
+	}
+
+	// Validate each element
+	for i, elem := range slice {
+		elemParamName := fmt.Sprintf("%s[%d]", paramName, i)
+		if err := b.validateArgType(elem, *expectedType.Elem, elemParamName, paramIndex); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *ABICallDataBuilder) validateArrayArg(arg interface{}, expectedType abi.Type, paramName string, paramIndex int) error {
+	slice, ok := arg.([]interface{})
+	if !ok {
+		return fmt.Errorf("parameter %s (index %d): expected array for %s, got %T", paramName, paramIndex, expectedType.String(), arg)
+	}
+
+	// Check fixed array size
+	if len(slice) != expectedType.Size {
+		return fmt.Errorf("parameter %s (index %d): expected array of size %d for %s, got %d elements",
+			paramName, paramIndex, expectedType.Size, expectedType.String(), len(slice))
+	}
+
+	// Validate each element
+	for i, elem := range slice {
+		elemParamName := fmt.Sprintf("%s[%d]", paramName, i)
+		if err := b.validateArgType(elem, *expectedType.Elem, elemParamName, paramIndex); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Add new calltx scenario with ABI-based calldata generation

Implements a new `calltx` scenario that deploys a contract and repeatedly calls a function on it. Features comprehensive ABI parsing and calldata building capabilities alongside raw hex calldata support.

## New Scenario Features

### Contract Deployment
- `--contract-code` - Deploy from hex bytecode
- `--contract-file` - Deploy from local file or HTTP URL
- `--contract-args` - Constructor arguments

### Function Calls - Raw Hex
- `--call-data` - Raw hex calldata for function calls

### Function Calls - ABI Support
- `--call-abi` - Full JSON ABI for function calls
- `--call-abi-file` - Load ABI from local file or HTTP URL  
- `--call-fn-name` - Function name (requires ABI)
- `--call-fn-sig` - Function signature parsing (e.g., `"transfer(address,uint256)"`)
- `--call-fn-args` - JSON arguments with placeholder support

### Dynamic Placeholders
- `{txid}` - Transaction index
- `{random}` - Random uint256
- `{random:N}` - Random number 0-N
- `{randomaddr}` - Random Ethereum address

### Validation & Safety
- Comprehensive argument validation against ABI types
- Function signature parsing with Solidity type validation
- Clear error messages for mismatched arguments
- Mutual exclusion of conflicting options

## Examples

### Deploy and call using function signature
```bash
spamoor calltx --contract-file "./contract.bin" \
  --call-fn-sig "transfer(address,uint256)" \
  --call-fn-args '["{randomaddr}", "{random:1000000}"]'
```

### Deploy and call using ABI file
```bash
spamoor calltx --contract-code "608060405234801561001057600080fd5b50..." \
  --call-abi-file "./erc20.json" \
  --call-fn-name "transfer" \
  --call-fn-args '["{randomaddr}", "1000"]'
```

### Deploy and call with raw hex calldata
```bash
spamoor calltx --contract-file "https://example.com/contract.bin" \
  --call-data "0xa9059cbb000000000000000000000000..."
```

### Complex function calls with placeholders
```bash
spamoor calltx --contract-file "./contract.bin" \
  --call-fn-sig "complexFunction(address,uint256,bool,string)" \
  --call-fn-args '["{randomaddr}", "{random}", true, "test-{txid}"]'
```

## Implementation Details

- **New scenario**: `scenarios/calltx/` - Complete scenario implementation
- **ABI handling**: `utils/abi.go` - Reusable ABI parsing and validation helper
- **Function signature parsing** - Supports all Solidity types including arrays and fixed arrays
- **Type validation** - Validates arguments against expected ABI types before conversion
- **Error handling** - Detailed error messages with parameter names and positions
- **File loading** - Supports both local files and HTTP/HTTPS URLs for contracts and ABIs