### PR TITLE
deploytx: fast exit if no bytecodes

### DIFF
--- a/scenarios/deploytx/deploytx.go
+++ b/scenarios/deploytx/deploytx.go
@@ -3,6 +3,7 @@ package deploytx
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -141,6 +142,10 @@ func (s *Scenario) Init(options *scenariotypes.ScenarioOptions) error {
 			}
 			s.bytecodes = append(s.bytecodes, common.FromHex(hexStr))
 		}
+	}
+
+	if len(s.bytecodes) == 0 {
+		return errors.New(`no bytecodes provided, please specify at least one bytecode to deploy(eg: --bytecodes "0x1234,0x5678")`)
 	}
 
 	return nil


### PR DESCRIPTION
When running `deploytx` without bytecodes, it will panic with `integer divide by zero`

```
# bin/spamoor deploytx -p $PRIVATE -h http://127.0.0.1:8545 -t 20
INFO[0002] starting spamoor                              buildtime="2025-06-04T01:30:43Z" version=git-f9dd53c
INFO[0002] initialized client pool with 1 clients (chain id: 1337)  module=clientpool
INFO[0002] client check completed (1 good clients, 0 bad clients)  module=clientpool
INFO[0002] initialized root wallet (addr: 0xe39Ccd9be6f5D7f2285f7BdDFFf31f7D7Fd04618 balance: 17073584222486134283 ETH, nonce: 100)
INFO[0002] initialized 100 child wallets                 module=walletpool
INFO[0002] starting scenario: deploytx                   scenario=deploytx
panic: runtime error: integer divide by zero

goroutine 782 [running]:
github.com/ethpandaops/spamoor/scenarios/deploytx.(*Scenario).sendTx(0xc0000d6370, {0xbbc0d0, 0xc0000f0460}, 0x0, 0xc000828090)
        /root/code/spamoor/scenarios/deploytx/deploytx.go:246 +0xcd4
github.com/ethpandaops/spamoor/scenarios/deploytx.(*Scenario).Run.func1({0xbbc0d0?, 0xc0000f0460?}, 0x0, 0x0?)
        /root/code/spamoor/scenarios/deploytx/deploytx.go:179 +0x5b
github.com/ethpandaops/spamoor/utils.RunTransactionScenario.func2(0x0, 0x0, 0xc000404000?)
        /root/code/spamoor/utils/scenario_helper.go:105 +0x149
created by github.com/ethpandaops/spamoor/utils.RunTransactionScenario in goroutine 1
        /root/code/spamoor/utils/scenario_helper.go:99 +0x445
```