### PR TITLE
add `spamoor run` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ make
 
 ### Basic Command Structure
 ```bash
+# Run a single scenario
 spamoor <scenario> [flags]
+
+# Run multiple scenarios from YAML configuration
+spamoor run <yaml-file> [flags]
 ```
 
 ### 🔑 Required Parameters
@@ -76,6 +80,76 @@ Spamoor provides a comprehensive suite of transaction scenarios for different te
 | [`xentoken`](./scenarios/xentoken/README.md) | **XEN Sybil Attack** - Simulate XEN token sybil attacks |
 | [`taskrunner`](./scenarios/taskrunner/README.md) | **Task Runner** - Execute configurable task sequences with init and execution phases |
 
+## 🚄 Run Command - Execute Multiple Scenarios
+
+The `spamoor run` command allows you to execute multiple scenarios concurrently from a YAML configuration file, without needing the full daemon infrastructure.
+
+### Usage
+```bash
+spamoor run <yaml-file> [flags]
+```
+
+### Flags
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--spammers` | `-s` | Indexes of spammers to run (e.g., `-s 0,2`). If not specified, runs all |
+| `--privkey` | `-p` | Private key for the root wallet |
+| `--rpchost` | `-h` | RPC endpoints (multiple allowed) |
+| `--rpchost-file` | - | File containing RPC endpoints |
+| `--verbose` | `-v` | Enable verbose logging |
+| `--trace` | - | Enable trace logging |
+
+### Example Configuration
+```yaml
+# example-run-config.yaml
+- scenario: eoatx
+  name: "High Volume ETH Transfers"
+  description: "Basic ETH transfers with 400 tx/slot throughput"
+  config:
+    seed: eoatx-demo
+    refill_amount: 1000000000000000000  # 1 ETH in wei
+    refill_balance: 500000000000000000  # 0.5 ETH in wei
+    refill_interval: 600  # 10 minutes
+    throughput: 400
+    max_pending: 800
+    max_wallets: 200
+    base_fee: 20  # gwei
+    tip_fee: 2    # gwei
+    amount: 100   # 100 wei per transfer
+    random_amount: true
+    random_target: true
+
+- scenario: erctx
+  name: "ERC20 Token Spammer"
+  description: "Deploy and transfer ERC20 tokens"
+  config:
+    seed: erctx-demo
+    refill_amount: 2000000000000000000  # 2 ETH
+    refill_balance: 1000000000000000000 # 1 ETH
+    throughput: 100
+    max_pending: 200
+    max_wallets: 100
+    amount: 50
+    random_amount: true
+    
+# Include other configuration files
+- include: ./high-load-configs.yaml
+```
+
+### Examples
+```bash
+# Run all spammers from configuration
+spamoor run config.yaml -h http://localhost:8545 -p 0x...
+
+# Run only specific spammers (0-based indexes)
+spamoor run config.yaml -h http://localhost:8545 -p 0x... -s 0,2
+
+# With multiple RPC endpoints
+spamoor run config.yaml -p 0x... \
+  -h http://node1:8545 \
+  -h http://node2:8545
+```
+
 ## 🖥️ Daemon Mode
 
 Run Spamoor as a daemon with a powerful web interface for managing multiple concurrent spammers.
@@ -95,6 +169,10 @@ spamoor-daemon [flags]
 | `--rpchost-file` | - | File containing RPC endpoints | - |
 | `--privkey` | `-p` | Root wallet private key | - |
 | `--port` | `-P` | Web UI port | `8080` |
+| `--startup-spammer` | - | YAML file or URL with startup spammers | - |
+| `--fulu-activation` | - | Unix timestamp of Fulu activation | `0` |
+| `--without-batcher` | - | Disable transaction batching | `false` |
+| `--disable-tx-metrics` | - | Disable transaction metrics collection | `false` |
 | `--verbose` | `-v` | Enable verbose logging | `false` |
 | `--debug` | - | Enable debug mode | `false` |
 | `--trace` | - | Enable trace logging | `false` |

--- a/cmd/spamoor/main.go
+++ b/cmd/spamoor/main.go
@@ -30,6 +30,12 @@ type CliArgs struct {
 }
 
 func main() {
+	// Check if "run" subcommand is used
+	if len(os.Args) >= 2 && os.Args[1] == "run" {
+		RunCommand(os.Args[2:])
+		return
+	}
+
 	cliArgs := CliArgs{}
 	flags := pflag.NewFlagSet("main", pflag.ContinueOnError)
 
@@ -71,7 +77,10 @@ func main() {
 	}
 	if invalidScenario {
 		fmt.Printf("invalid or missing scenario\n\n")
-		fmt.Printf("implemented scenarios:\n")
+		fmt.Printf("Usage:\n")
+		fmt.Printf("  spamoor <scenario> [options]     Run a specific scenario\n")
+		fmt.Printf("  spamoor run <yaml-file> [options] Run multiple scenarios from YAML config\n\n")
+		fmt.Printf("Implemented scenarios:\n")
 		scenarioNames := scenarios.GetScenarioNames()
 		sort.Slice(scenarioNames, func(a int, b int) bool {
 			return strings.Compare(scenarioNames[a], scenarioNames[b]) > 0

--- a/cmd/spamoor/run.go
+++ b/cmd/spamoor/run.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/ethpandaops/spamoor/daemon"
+	"github.com/ethpandaops/spamoor/scenario"
+	"github.com/ethpandaops/spamoor/scenarios"
+	"github.com/ethpandaops/spamoor/spamoor"
+	"github.com/ethpandaops/spamoor/utils"
+)
+
+// RunSpammer represents a spammer instance for the run command
+type RunSpammer struct {
+	config     daemon.ExportSpammerConfig
+	scenario   scenario.Scenario
+	walletPool *spamoor.WalletPool
+	logger     *logrus.Entry
+}
+
+// RunCommand handles the run subcommand
+func RunCommand(args []string) {
+	cliArgs := CliArgs{}
+	var selectedSpammers []int
+
+	flags := pflag.NewFlagSet("run", pflag.ExitOnError)
+	flags.BoolVarP(&cliArgs.verbose, "verbose", "v", false, "Run with verbose output")
+	flags.BoolVar(&cliArgs.trace, "trace", false, "Run with tracing output")
+	flags.StringArrayVarP(&cliArgs.rpchosts, "rpchost", "h", []string{}, "The RPC host to send transactions to.")
+	flags.StringVar(&cliArgs.rpchostsFile, "rpchost-file", "", "File with a list of RPC hosts to send transactions to.")
+	flags.StringVarP(&cliArgs.privkey, "privkey", "p", "", "The private key of the wallet to send funds from.")
+	flags.IntSliceVarP(&selectedSpammers, "spammers", "s", []int{}, "Indexes of spammers to run (0-based). If not specified, runs all spammers.")
+
+	flags.Parse(args)
+
+	if flags.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "Error: missing YAML file path\n")
+		fmt.Fprintf(os.Stderr, "Usage: spamoor run <yaml-file> [options]\n")
+		os.Exit(1)
+	}
+
+	yamlFile := flags.Args()[0]
+
+	// Set log level
+	if cliArgs.trace {
+		logrus.SetLevel(logrus.TraceLevel)
+	} else if cliArgs.verbose {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	// Initialize logger
+	logger := logrus.StandardLogger()
+	logger.WithFields(logrus.Fields{
+		"version":   utils.GetBuildVersion(),
+		"buildtime": utils.BuildTime,
+	}).Infof("starting spamoor run command")
+
+	// Create context
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	go func() {
+		<-sigChan
+		logger.Info("Received interrupt signal, shutting down...")
+		cancel()
+	}()
+
+	// Initialize client pool
+	rpcHosts := []string{}
+	for _, rpcHost := range cliArgs.rpchosts {
+		if rpcHost != "" {
+			rpcHosts = append(rpcHosts, rpcHost)
+		}
+	}
+
+	if cliArgs.rpchostsFile != "" {
+		fileLines, err := utils.ReadFileLinesTrimmed(cliArgs.rpchostsFile)
+		if err != nil {
+			logger.WithError(err).Fatal("Failed to read RPC hosts file")
+		}
+		rpcHosts = append(rpcHosts, fileLines...)
+	}
+
+	if len(rpcHosts) == 0 {
+		logger.Fatal("No RPC hosts specified")
+	}
+
+	clientPool := spamoor.NewClientPool(ctx, rpcHosts, logger.WithField("module", "clientpool"))
+	err := clientPool.PrepareClients()
+	if err != nil {
+		logger.WithError(err).Fatal("Failed to prepare clients")
+	}
+
+	// Initialize root wallet
+	client := clientPool.GetClient(spamoor.SelectClientRandom, 0, "")
+	if client == nil {
+		logger.Fatal("No client available")
+	}
+
+	rootWallet, err := spamoor.InitRootWallet(ctx, cliArgs.privkey, client, logger)
+	if err != nil {
+		logger.WithError(err).Fatal("Failed to init root wallet")
+	}
+
+	// Load and parse YAML file using daemon's import logic
+	spammerConfigs, err := daemon.ResolveImportConfigs(yamlFile, "", make(map[string]bool))
+	if err != nil {
+		logger.WithError(err).Fatal("Failed to load spammer configurations")
+	}
+
+	if len(spammerConfigs) == 0 {
+		logger.Fatal("No spammer configurations found in YAML file")
+	}
+
+	// Validate configurations
+	for i, config := range spammerConfigs {
+		if config.Scenario == "" {
+			logger.Fatalf("Spammer %d: missing scenario", i)
+		}
+
+		scenario := scenarios.GetScenario(config.Scenario)
+		if scenario == nil {
+			logger.Fatalf("Spammer %d: unknown scenario '%s'", i, config.Scenario)
+		}
+
+		if config.Name == "" {
+			config.Name = fmt.Sprintf("Spammer %d", i+1)
+			spammerConfigs[i] = config
+		}
+	}
+
+	// Filter spammers if specified
+	var configsToRun []daemon.ExportSpammerConfig
+	if len(selectedSpammers) > 0 {
+		for _, idx := range selectedSpammers {
+			if idx < 0 || idx >= len(spammerConfigs) {
+				logger.Fatalf("Invalid spammer index %d (valid range: 0-%d)", idx, len(spammerConfigs)-1)
+			}
+			configsToRun = append(configsToRun, spammerConfigs[idx])
+		}
+	} else {
+		configsToRun = spammerConfigs
+	}
+
+	logger.Infof("Preparing to run %d spammer(s)", len(configsToRun))
+
+	// Create wallet pools slice for txpool
+	walletPools := []*spamoor.WalletPool{}
+	walletPoolMutex := &sync.RWMutex{}
+
+	// Initialize transaction pool
+	txpool := spamoor.NewTxPool(&spamoor.TxPoolOptions{
+		Context:    ctx,
+		ClientPool: clientPool,
+		GetActiveWalletPools: func() []*spamoor.WalletPool {
+			walletPoolMutex.RLock()
+			defer walletPoolMutex.RUnlock()
+			return walletPools
+		},
+	})
+
+	// Create and initialize spammers
+	spammers := make([]*RunSpammer, len(configsToRun))
+	for i, config := range configsToRun {
+		spammer, err := createSpammer(ctx, config, rootWallet, clientPool, txpool, logger, i)
+		if err != nil {
+			logger.WithError(err).Fatalf("Failed to create spammer %d (%s)", i, config.Name)
+		}
+		spammers[i] = spammer
+
+		// Add wallet pool to the slice
+		walletPoolMutex.Lock()
+		walletPools = append(walletPools, spammer.walletPool)
+		walletPoolMutex.Unlock()
+	}
+
+	// Prepare all wallet pools
+	logger.Info("Preparing wallets for all spammers...")
+	var wg sync.WaitGroup
+	for i, spammer := range spammers {
+		wg.Add(1)
+		go func(idx int, s *RunSpammer) {
+			defer wg.Done()
+			err := s.walletPool.PrepareWallets()
+			if err != nil {
+				logger.WithError(err).Fatalf("Failed to prepare wallets for spammer %d (%s)", idx, s.config.Name)
+			}
+			logger.Infof("Wallets prepared for spammer %d (%s)", idx, s.config.Name)
+		}(i, spammer)
+	}
+	wg.Wait()
+
+	// Run all spammers concurrently
+	logger.Info("Starting all spammers...")
+	errChan := make(chan error, len(spammers))
+
+	for i, spammer := range spammers {
+		wg.Add(1)
+		go func(idx int, s *RunSpammer) {
+			defer wg.Done()
+			logger.Infof("Starting spammer %d: %s (%s)", idx, s.config.Name, s.config.Scenario)
+			err := s.scenario.Run(ctx)
+			if err != nil {
+				errChan <- fmt.Errorf("spammer %d (%s) failed: %w", idx, s.config.Name, err)
+			}
+		}(i, spammer)
+	}
+
+	// Wait for context cancellation or errors
+	go func() {
+		wg.Wait()
+		close(errChan)
+	}()
+
+	// Monitor for errors
+	for err := range errChan {
+		if err != nil {
+			logger.WithError(err).Error("Spammer error")
+		}
+	}
+
+	logger.Info("All spammers completed")
+}
+
+// createSpammer creates and initializes a spammer instance
+func createSpammer(ctx context.Context, config daemon.ExportSpammerConfig, rootWallet *spamoor.RootWallet,
+	clientPool *spamoor.ClientPool, txpool *spamoor.TxPool, logger *logrus.Logger, index int) (*RunSpammer, error) {
+
+	// Get scenario descriptor
+	descriptor := scenarios.GetScenario(config.Scenario)
+	if descriptor == nil {
+		return nil, fmt.Errorf("unknown scenario: %s", config.Scenario)
+	}
+
+	// Create logger for this spammer
+	spammerLogger := logger.WithFields(logrus.Fields{
+		"spammer":  index,
+		"scenario": config.Scenario,
+		"name":     config.Name,
+	})
+
+	// Create scenario instance
+	scenarioInstance := descriptor.NewScenario(spammerLogger)
+	if scenarioInstance == nil {
+		return nil, fmt.Errorf("failed to create scenario instance")
+	}
+
+	// Create wallet pool for this spammer
+	walletPool := spamoor.NewWalletPool(ctx, spammerLogger.WithField("module", "walletpool"),
+		rootWallet, clientPool, txpool)
+
+	// Merge configuration with defaults using daemon's method
+	configYAML, err := daemon.MergeConfiguration(descriptor, config.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge configuration: %w", err)
+	}
+
+	// Initialize scenario
+	if err := scenarioInstance.Init(&scenario.Options{
+		WalletPool: walletPool,
+		Config:     configYAML,
+		GlobalCfg:  config.Config,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to initialize scenario: %w", err)
+	}
+
+	// Load config to wallet pool
+	if err := walletPool.LoadConfig(configYAML); err != nil {
+		return nil, fmt.Errorf("failed to load wallet config: %w", err)
+	}
+
+	return &RunSpammer{
+		config:     config,
+		scenario:   scenarioInstance,
+		walletPool: walletPool,
+		logger:     spammerLogger,
+	}, nil
+}

--- a/daemon/configs/configs.go
+++ b/daemon/configs/configs.go
@@ -1,0 +1,274 @@
+package configs
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ethpandaops/spamoor/scenario"
+	"github.com/ethpandaops/spamoor/spamoor"
+)
+
+// SpammerConfig represents a spammer configuration for export/import.
+// This uses the same format as StartupSpammerConfig to maintain compatibility.
+type SpammerConfig struct {
+	Scenario    string                 `yaml:"scenario"`
+	Name        string                 `yaml:"name"`
+	Description string                 `yaml:"description"`
+	Config      map[string]interface{} `yaml:"config"`
+}
+
+// ConfigImportItem represents either a spammer config or an include directive
+type ConfigImportItem struct {
+	// Spammer configuration fields
+	Scenario    string                 `yaml:"scenario,omitempty"`
+	Name        string                 `yaml:"name,omitempty"`
+	Description string                 `yaml:"description,omitempty"`
+	Config      map[string]interface{} `yaml:"config,omitempty"`
+
+	// Include directive
+	Include string `yaml:"include,omitempty"`
+}
+
+// ResolveConfigImports recursively resolves includes and returns the final spammer configs
+func ResolveConfigImports(input string, baseURL string, visited map[string]bool) ([]SpammerConfig, error) {
+	// Resolve the actual source path/URL
+	resolvedInput := resolveConfigIncludePath(input, baseURL)
+
+	// Prevent circular includes
+	if visited[resolvedInput] {
+		return nil, fmt.Errorf("circular include detected: %s", resolvedInput)
+	}
+	visited[resolvedInput] = true
+	defer func() { delete(visited, resolvedInput) }()
+
+	// Get the YAML data
+	var yamlData string
+	var err error
+
+	// Check if resolved input is a URL
+	if isConfigURL(resolvedInput) {
+		yamlData, err = downloadConfigFromURL(resolvedInput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download from URL: %w", err)
+		}
+	} else if isConfigFilePath(resolvedInput) {
+		// Try to read as file path
+		yamlData, err = readConfigFromFile(resolvedInput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from file: %w", err)
+		}
+	} else {
+		// Treat as raw YAML data (only for root input)
+		yamlData = resolvedInput
+	}
+
+	// Parse as ConfigImportItems to handle both configs and includes
+	var importItems []ConfigImportItem
+	if err := yaml.Unmarshal([]byte(yamlData), &importItems); err != nil {
+		return nil, fmt.Errorf("failed to parse import data: %w", err)
+	}
+
+	var allConfigs []SpammerConfig
+
+	// Determine the new base URL/path for nested includes
+	newBaseURL := getConfigBaseURL(resolvedInput)
+
+	// Process each item
+	for _, item := range importItems {
+		if item.Include != "" {
+			// This is an include directive
+			includedConfigs, err := ResolveConfigImports(item.Include, newBaseURL, visited)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve include '%s': %w", item.Include, err)
+			}
+			allConfigs = append(allConfigs, includedConfigs...)
+		} else {
+			// This is a spammer configuration
+			config := SpammerConfig{
+				Scenario:    item.Scenario,
+				Name:        item.Name,
+				Description: item.Description,
+				Config:      item.Config,
+			}
+			allConfigs = append(allConfigs, config)
+		}
+	}
+
+	return allConfigs, nil
+}
+
+// MergeScenarioConfiguration merges scenario defaults with provided configuration
+func MergeScenarioConfiguration(scenario *scenario.Descriptor, providedConfig map[string]interface{}) (string, error) {
+	// Get default configurations
+	defaultYaml, err := yaml.Marshal(scenario.DefaultOptions)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal default config: %w", err)
+	}
+
+	defaultWalletConfig := spamoor.GetDefaultWalletConfig(scenario.Name)
+	defaultWalletConfigYaml, err := yaml.Marshal(defaultWalletConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal default wallet config: %w", err)
+	}
+
+	// Merge configurations
+	mergedConfig := map[string]interface{}{}
+
+	if err := yaml.Unmarshal(defaultWalletConfigYaml, &mergedConfig); err != nil {
+		return "", fmt.Errorf("failed to unmarshal default wallet config: %w", err)
+	}
+
+	if err := yaml.Unmarshal(defaultYaml, &mergedConfig); err != nil {
+		return "", fmt.Errorf("failed to unmarshal default config: %w", err)
+	}
+
+	// Apply provided config overrides
+	for k, v := range providedConfig {
+		mergedConfig[k] = v
+	}
+
+	configYAML, err := yaml.Marshal(mergedConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal merged config: %w", err)
+	}
+
+	return string(configYAML), nil
+}
+
+// isConfigURL checks if the input string is a valid URL
+func isConfigURL(input string) bool {
+	parsedURL, err := url.Parse(input)
+	if err != nil {
+		return false
+	}
+	return parsedURL.Scheme == "http" || parsedURL.Scheme == "https"
+}
+
+// isConfigFilePath checks if the input string looks like a file path
+func isConfigFilePath(input string) bool {
+	// Check if it contains YAML content markers (likely raw YAML)
+	if len(input) > 0 && (input[0] == '-' || input[0] == '[' || input[0] == '{') {
+		return false
+	}
+
+	// Check if file exists
+	if _, err := os.Stat(input); err == nil {
+		return true
+	}
+
+	// Check if it looks like a path (contains / or \)
+	return len(input) > 0 && (input[0] == '/' || input[0] == '.' || input[0] == '~' ||
+		(len(input) > 1 && input[1] == ':')) // Windows drive letter
+}
+
+// readConfigFromFile reads YAML data from a local file
+func readConfigFromFile(filePath string) (string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
+	}
+	return string(data), nil
+}
+
+// downloadConfigFromURL downloads YAML data from a remote URL
+func downloadConfigFromURL(urlStr string) (string, error) {
+	// Validate URL
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return "", fmt.Errorf("unsupported URL scheme: %s", parsedURL.Scheme)
+	}
+
+	// Download the YAML data
+	resp, err := http.Get(urlStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to download from URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP error %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	yamlData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return string(yamlData), nil
+}
+
+// resolveConfigIncludePath resolves an include path against a base URL or directory
+func resolveConfigIncludePath(includePath, baseURL string) string {
+	// If include path is absolute (URL or absolute file path), return as-is
+	if isConfigURL(includePath) || filepath.IsAbs(includePath) {
+		return includePath
+	}
+
+	// If no base URL provided, return the include path as-is
+	if baseURL == "" {
+		return includePath
+	}
+
+	// If base is a URL, resolve relative URL
+	if isConfigURL(baseURL) {
+		baseURLParsed, err := url.Parse(baseURL)
+		if err != nil {
+			return includePath // fallback to original
+		}
+
+		resolvedURL, err := baseURLParsed.Parse(includePath)
+		if err != nil {
+			return includePath // fallback to original
+		}
+
+		return resolvedURL.String()
+	}
+
+	// If base is a file path, resolve relative to directory
+	if isConfigFilePath(baseURL) {
+		baseDir := filepath.Dir(baseURL)
+		return filepath.Join(baseDir, includePath)
+	}
+
+	// Fallback to original include path
+	return includePath
+}
+
+// getConfigBaseURL extracts the base URL or directory from a source path
+func getConfigBaseURL(sourcePath string) string {
+	if isConfigURL(sourcePath) {
+		// For URLs, get the base URL (everything except the filename)
+		parsedURL, err := url.Parse(sourcePath)
+		if err != nil {
+			return ""
+		}
+
+		// Remove the filename from the path
+		parsedURL.Path = path.Dir(parsedURL.Path)
+		if !strings.HasSuffix(parsedURL.Path, "/") {
+			parsedURL.Path += "/"
+		}
+
+		return parsedURL.String()
+	}
+
+	if isConfigFilePath(sourcePath) {
+		// For file paths, return the directory
+		return filepath.Dir(sourcePath)
+	}
+
+	// For raw YAML data, no base URL
+	return ""
+}

--- a/daemon/export_import.go
+++ b/daemon/export_import.go
@@ -2,40 +2,18 @@ package daemon
 
 import (
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 
-	"github.com/ethpandaops/spamoor/scenario"
-	"github.com/ethpandaops/spamoor/scenarios"
-	"github.com/ethpandaops/spamoor/spamoor"
 	"gopkg.in/yaml.v3"
+
+	"github.com/ethpandaops/spamoor/daemon/configs"
+	"github.com/ethpandaops/spamoor/scenarios"
 )
 
-// ExportSpammerConfig represents a spammer configuration for export/import.
-// This uses the same format as StartupSpammerConfig to maintain compatibility.
-type ExportSpammerConfig struct {
-	Scenario    string                 `yaml:"scenario"`
-	Name        string                 `yaml:"name"`
-	Description string                 `yaml:"description"`
-	Config      map[string]interface{} `yaml:"config"`
-}
+// ExportSpammerConfig is an alias for scenario.SpammerConfig to maintain API compatibility
+type ExportSpammerConfig = configs.SpammerConfig
 
-// ImportItem represents either a spammer config or an include directive
-type ImportItem struct {
-	// Spammer configuration fields
-	Scenario    string                 `yaml:"scenario,omitempty"`
-	Name        string                 `yaml:"name,omitempty"`
-	Description string                 `yaml:"description,omitempty"`
-	Config      map[string]interface{} `yaml:"config,omitempty"`
-
-	// Include directive
-	Include string `yaml:"include,omitempty"`
-}
+// ImportItem is an alias for scenario.ConfigImportItem to maintain API compatibility
+type ImportItem = configs.ConfigImportItem
 
 // ExportSpammers exports the specified spammer IDs to YAML format.
 // If no IDs are provided, exports all spammers.
@@ -92,7 +70,7 @@ func (d *Daemon) ExportSpammers(spammerIDs ...int64) (string, error) {
 // Returns validation results and the number of spammers imported.
 func (d *Daemon) ImportSpammers(input string) (*ImportResult, error) {
 	// Resolve all includes and get the final spammer configs
-	importConfigs, err := ResolveImportConfigs(input, "", make(map[string]bool))
+	importConfigs, err := configs.ResolveConfigImports(input, "", make(map[string]bool))
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve import configs: %w", err)
 	}
@@ -118,8 +96,8 @@ func (d *Daemon) ImportSpammers(input string) (*ImportResult, error) {
 
 	for _, importConfig := range importConfigs {
 		// Skip invalid scenarios (already validated)
-		scenario := scenarios.GetScenario(importConfig.Scenario)
-		if scenario == nil {
+		scenarioDescriptor := scenarios.GetScenario(importConfig.Scenario)
+		if scenarioDescriptor == nil {
 			importErrors = append(importErrors, fmt.Sprintf("Scenario '%s' not found", importConfig.Scenario))
 			continue
 		}
@@ -133,7 +111,7 @@ func (d *Daemon) ImportSpammers(input string) (*ImportResult, error) {
 		finalName := importConfig.Name
 
 		// Merge default configuration with imported config
-		configYAML, err := MergeConfiguration(scenario, importConfig.Config)
+		configYAML, err := configs.MergeScenarioConfiguration(scenarioDescriptor, importConfig.Config)
 		if err != nil {
 			errMsg := fmt.Sprintf("Failed to merge config for spammer '%s': %v", finalName, err)
 			importErrors = append(importErrors, errMsg)
@@ -173,140 +151,6 @@ func (d *Daemon) ImportSpammers(input string) (*ImportResult, error) {
 	}, nil
 }
 
-// isURL checks if the input string is a valid URL
-func isURL(input string) bool {
-	parsedURL, err := url.Parse(input)
-	if err != nil {
-		return false
-	}
-	return parsedURL.Scheme == "http" || parsedURL.Scheme == "https"
-}
-
-// isFilePath checks if the input string looks like a file path
-func isFilePath(input string) bool {
-	// Check if it contains YAML content markers (likely raw YAML)
-	if len(input) > 0 && (input[0] == '-' || input[0] == '[' || input[0] == '{') {
-		return false
-	}
-
-	// Check if file exists
-	if _, err := os.Stat(input); err == nil {
-		return true
-	}
-
-	// Check if it looks like a path (contains / or \)
-	return len(input) > 0 && (input[0] == '/' || input[0] == '.' || input[0] == '~' ||
-		(len(input) > 1 && input[1] == ':')) // Windows drive letter
-}
-
-// readFromFile reads YAML data from a local file (standalone function)
-func readFromFile(filePath string) (string, error) {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read file %s: %w", filePath, err)
-	}
-	return string(data), nil
-}
-
-// downloadFromURL downloads YAML data from a remote URL (standalone function)
-func downloadFromURL(urlStr string) (string, error) {
-	// Validate URL
-	parsedURL, err := url.Parse(urlStr)
-	if err != nil {
-		return "", fmt.Errorf("invalid URL: %w", err)
-	}
-
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return "", fmt.Errorf("unsupported URL scheme: %s", parsedURL.Scheme)
-	}
-
-	// Download the YAML data
-	resp, err := http.Get(urlStr)
-	if err != nil {
-		return "", fmt.Errorf("failed to download from URL: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("HTTP error %d: %s", resp.StatusCode, resp.Status)
-	}
-
-	yamlData, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	return string(yamlData), nil
-}
-
-// ResolveImportConfigs recursively resolves includes and returns the final spammer configs (standalone function)
-func ResolveImportConfigs(input string, baseURL string, visited map[string]bool) ([]ExportSpammerConfig, error) {
-	// Resolve the actual source path/URL
-	resolvedInput := resolveIncludePath(input, baseURL)
-
-	// Prevent circular includes
-	if visited[resolvedInput] {
-		return nil, fmt.Errorf("circular include detected: %s", resolvedInput)
-	}
-	visited[resolvedInput] = true
-	defer func() { delete(visited, resolvedInput) }()
-
-	// Get the YAML data
-	var yamlData string
-	var err error
-
-	// Check if resolved input is a URL
-	if isURL(resolvedInput) {
-		yamlData, err = downloadFromURL(resolvedInput)
-		if err != nil {
-			return nil, fmt.Errorf("failed to download from URL: %w", err)
-		}
-	} else if isFilePath(resolvedInput) {
-		// Try to read as file path
-		yamlData, err = readFromFile(resolvedInput)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read from file: %w", err)
-		}
-	} else {
-		// Treat as raw YAML data (only for root input)
-		yamlData = resolvedInput
-	}
-
-	// Parse as ImportItems to handle both configs and includes
-	var importItems []ImportItem
-	if err := yaml.Unmarshal([]byte(yamlData), &importItems); err != nil {
-		return nil, fmt.Errorf("failed to parse import data: %w", err)
-	}
-
-	var allConfigs []ExportSpammerConfig
-
-	// Determine the new base URL/path for nested includes
-	newBaseURL := getBaseURL(resolvedInput)
-
-	// Process each item
-	for _, item := range importItems {
-		if item.Include != "" {
-			// This is an include directive
-			includedConfigs, err := ResolveImportConfigs(item.Include, newBaseURL, visited)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve include '%s': %w", item.Include, err)
-			}
-			allConfigs = append(allConfigs, includedConfigs...)
-		} else {
-			// This is a spammer configuration
-			config := ExportSpammerConfig{
-				Scenario:    item.Scenario,
-				Name:        item.Name,
-				Description: item.Description,
-				Config:      item.Config,
-			}
-			allConfigs = append(allConfigs, config)
-		}
-	}
-
-	return allConfigs, nil
-}
-
 // validateImportConfigs validates spammer configurations
 func (d *Daemon) validateImportConfigs(importConfigs []ExportSpammerConfig) (*ImportValidationResult, error) {
 	result := &ImportValidationResult{
@@ -333,8 +177,8 @@ func (d *Daemon) validateImportConfigs(importConfigs []ExportSpammerConfig) (*Im
 		}
 
 		// Check scenario validity
-		scenario := scenarios.GetScenario(importConfig.Scenario)
-		if scenario == nil {
+		scenarioDescriptor := scenarios.GetScenario(importConfig.Scenario)
+		if scenarioDescriptor == nil {
 			info.Valid = false
 			info.Issues = append(info.Issues, "Unknown scenario")
 			result.InvalidScenarios = append(result.InvalidScenarios, importConfig.Scenario)
@@ -365,44 +209,6 @@ func (d *Daemon) spammerExistsByScenarioAndName(scenario, name string) bool {
 		}
 	}
 	return false
-}
-
-// MergeConfiguration merges scenario defaults with imported configuration (standalone function)
-func MergeConfiguration(scenario *scenario.Descriptor, importedConfig map[string]interface{}) (string, error) {
-	// Get default configurations
-	defaultYaml, err := yaml.Marshal(scenario.DefaultOptions)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal default config: %w", err)
-	}
-
-	defaultWalletConfig := spamoor.GetDefaultWalletConfig(scenario.Name)
-	defaultWalletConfigYaml, err := yaml.Marshal(defaultWalletConfig)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal default wallet config: %w", err)
-	}
-
-	// Merge configurations
-	mergedConfig := map[string]interface{}{}
-
-	if err := yaml.Unmarshal(defaultWalletConfigYaml, &mergedConfig); err != nil {
-		return "", fmt.Errorf("failed to unmarshal default wallet config: %w", err)
-	}
-
-	if err := yaml.Unmarshal(defaultYaml, &mergedConfig); err != nil {
-		return "", fmt.Errorf("failed to unmarshal default config: %w", err)
-	}
-
-	// Apply imported config overrides
-	for k, v := range importedConfig {
-		mergedConfig[k] = v
-	}
-
-	configYAML, err := yaml.Marshal(mergedConfig)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal merged config: %w", err)
-	}
-
-	return string(configYAML), nil
 }
 
 // ImportResult contains the results of an import operation
@@ -438,68 +244,4 @@ type SpammerValidationInfo struct {
 	Description string   `json:"description"`
 	Valid       bool     `json:"valid"`
 	Issues      []string `json:"issues"`
-}
-
-// resolveIncludePath resolves an include path against a base URL or directory (standalone function)
-func resolveIncludePath(includePath, baseURL string) string {
-	// If include path is absolute (URL or absolute file path), return as-is
-	if isURL(includePath) || filepath.IsAbs(includePath) {
-		return includePath
-	}
-
-	// If no base URL provided, return the include path as-is
-	if baseURL == "" {
-		return includePath
-	}
-
-	// If base is a URL, resolve relative URL
-	if isURL(baseURL) {
-		baseURLParsed, err := url.Parse(baseURL)
-		if err != nil {
-			return includePath // fallback to original
-		}
-
-		resolvedURL, err := baseURLParsed.Parse(includePath)
-		if err != nil {
-			return includePath // fallback to original
-		}
-
-		return resolvedURL.String()
-	}
-
-	// If base is a file path, resolve relative to directory
-	if isFilePath(baseURL) {
-		baseDir := filepath.Dir(baseURL)
-		return filepath.Join(baseDir, includePath)
-	}
-
-	// Fallback to original include path
-	return includePath
-}
-
-// getBaseURL extracts the base URL or directory from a source path (standalone function)
-func getBaseURL(sourcePath string) string {
-	if isURL(sourcePath) {
-		// For URLs, get the base URL (everything except the filename)
-		parsedURL, err := url.Parse(sourcePath)
-		if err != nil {
-			return ""
-		}
-
-		// Remove the filename from the path
-		parsedURL.Path = path.Dir(parsedURL.Path)
-		if !strings.HasSuffix(parsedURL.Path, "/") {
-			parsedURL.Path += "/"
-		}
-
-		return parsedURL.String()
-	}
-
-	if isFilePath(sourcePath) {
-		// For file paths, return the directory
-		return filepath.Dir(sourcePath)
-	}
-
-	// For raw YAML data, no base URL
-	return ""
 }


### PR DESCRIPTION
# Add `spamoor run` command for YAML-based multi-scenario execution

## Summary

Adds a new `spamoor run` subcommand that executes multiple scenarios concurrently from YAML configuration files, providing a lightweight alternative to daemon mode.

## Changes

### Core Implementation
- **New `spamoor run` subcommand** (`cmd/spamoor/run.go`)
  - Executes multiple scenarios from YAML configuration files
  - Supports spammer selection via `--spammers` flag (e.g., `-s 0,2`)
  - Reuses all base CLI flags (`--rpchost`, `--privkey`, etc.)
  - Lightweight execution without database or web interface

### Daemon Refactoring
- **Extracted standalone functions** in `daemon/export_import.go`
  - `ResolveImportConfigs()` - YAML parsing with include resolution
  - `MergeConfiguration()` - Configuration merging with defaults
  - `readFromFile()`, `downloadFromURL()` - File/URL handling
  - Maintains backward compatibility with existing daemon methods

### Documentation Updates
- **Updated README.md** with `spamoor run` section and examples
- **Enhanced docs/app-users.md** with comprehensive run command documentation

## Usage Examples

```bash
# Run all spammers from config
spamoor run config.yaml -h http://localhost:8545 -p 0x...

# Run specific spammers by index
spamoor run config.yaml -h http://localhost:8545 -p 0x... -s 0,2

# With multiple RPC endpoints
spamoor run config.yaml -p 0x... -h http://node1:8545 -h http://node2:8545
```