### PR TITLE
fix: accept already known transactions as success

### DIFF
--- a/spamoor/txpool.go
+++ b/spamoor/txpool.go
@@ -828,8 +828,7 @@ func (pool *TxPool) submitTransaction(ctx context.Context, wallet *Wallet, tx *t
 			if options.LogFn != nil {
 				options.LogFn(client, i, 0, err)
 			}
-
-			if err == nil {
+			if err == nil || (strings.Contains(err.Error(), "already known") || strings.Contains(err.Error(), "Known transaction")) {
 				success = true
 				submitCount--
 				if submitCount == 0 {


### PR DESCRIPTION
when submitting a transaction without `submitCount`, spamoor automatically tries to send the transaction to 3 clients from the client pool, retrying until it successes for third time. 

When the clients are well connected, the sent transaction is gossiped to other clients, so sending that tx to other clients may return `already known` or `known transaction` errors. 
This causes spamoor to loop through all the client list, continuing to send tx to the next client in the pool, sending unnecessary tx and creating lots of logs. 

We could consider already known transactions as succeeded, like how it's done in rebroadcasts https://github.com/ethpandaops/spamoor/blob/d001e9de492875365e30a322132226b5f430b3ac/spamoor/txpool.go#L1288
