### PR TITLE
fix pending nonce tracking with randomly offline clients

### DIFF
--- a/scenarios/blob-combined/blob_combined.go
+++ b/scenarios/blob-combined/blob_combined.go
@@ -242,6 +242,10 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64, wallet *spamoor
 		return nil, client, wallet, 0, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, 0, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, 0, err
@@ -367,7 +371,12 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64, wallet *spamoor
 	if err != nil {
 		if replacementIdx == 0 {
 			// reset nonce if tx was not sent
-			wallet.ResetPendingNonce(s.walletPool.GetContext(), client)
+			wallet.ResetPendingNonce(s.walletPool.GetContext(), client, func() *spamoor.Client {
+				return s.walletPool.GetClient(
+					spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+					spamoor.WithClientGroup(s.options.ClientGroup),
+				)
+			})
 		}
 
 		return nil, client, wallet, 0, err

--- a/scenarios/blob-conflicting/blob_conflicting.go
+++ b/scenarios/blob-conflicting/blob_conflicting.go
@@ -229,6 +229,10 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64, onComplete func
 		return nil, client, wallet, 0, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, 0, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, 0, err
@@ -380,7 +384,12 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64, onComplete func
 	}
 	if errCount == 2 {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(s.walletPool.GetContext(), client)
+		wallet.ResetPendingNonce(s.walletPool.GetContext(), client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 	}
 	if errCount == 0 {
 		return nil, nil, wallet, 0, err1

--- a/scenarios/blobs/blobs.go
+++ b/scenarios/blobs/blobs.go
@@ -224,6 +224,10 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64, onComplete func
 		return nil, client, wallet, 0, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, 0, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, 0, err
@@ -350,7 +354,12 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64, onComplete func
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(s.walletPool.GetContext(), client)
+		wallet.ResetPendingNonce(s.walletPool.GetContext(), client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
 		return nil, client, wallet, 0, err
 	}

--- a/scenarios/calltx/calltx.go
+++ b/scenarios/calltx/calltx.go
@@ -429,6 +429,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -519,9 +523,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil

--- a/scenarios/deploy-destruct/deploy_destruct.go
+++ b/scenarios/deploy-destruct/deploy_destruct.go
@@ -270,6 +270,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -324,9 +328,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil

--- a/scenarios/deploytx/deploytx.go
+++ b/scenarios/deploytx/deploytx.go
@@ -241,6 +241,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -304,9 +308,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil

--- a/scenarios/eoatx/eoatx.go
+++ b/scenarios/eoatx/eoatx.go
@@ -222,6 +222,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -304,9 +308,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil

--- a/scenarios/erctx/erctx.go
+++ b/scenarios/erctx/erctx.go
@@ -269,6 +269,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -330,9 +334,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil

--- a/scenarios/factorydeploytx/factorydeploytx.go
+++ b/scenarios/factorydeploytx/factorydeploytx.go
@@ -325,6 +325,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -389,9 +393,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil

--- a/scenarios/gasburnertx/gasburnertx.go
+++ b/scenarios/gasburnertx/gasburnertx.go
@@ -385,6 +385,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -453,9 +457,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil

--- a/scenarios/geastx/geastx.go
+++ b/scenarios/geastx/geastx.go
@@ -364,6 +364,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -418,9 +422,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil

--- a/scenarios/setcodetx/setcodetx.go
+++ b/scenarios/setcodetx/setcodetx.go
@@ -246,6 +246,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -319,9 +323,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil

--- a/scenarios/uniswap-swaps/uniswap_swaps.go
+++ b/scenarios/uniswap-swaps/uniswap_swaps.go
@@ -268,6 +268,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -527,9 +531,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil

--- a/scenarios/xentoken/xentoken.go
+++ b/scenarios/xentoken/xentoken.go
@@ -240,6 +240,10 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 		return nil, client, wallet, fmt.Errorf("no client available")
 	}
 
+	if err := wallet.ResetNoncesIfNeeded(ctx, client); err != nil {
+		return nil, client, wallet, err
+	}
+
 	feeCap, tipCap, err := s.walletPool.GetTxPool().GetSuggestedFees(client, s.options.BaseFee, s.options.TipFee)
 	if err != nil {
 		return nil, client, wallet, err
@@ -285,9 +289,14 @@ func (s *Scenario) sendTx(ctx context.Context, txIdx uint64, onComplete func()) 
 	})
 	if err != nil {
 		// reset nonce if tx was not sent
-		wallet.ResetPendingNonce(ctx, client)
+		wallet.ResetPendingNonce(ctx, client, func() *spamoor.Client {
+			return s.walletPool.GetClient(
+				spamoor.WithClientSelectionMode(spamoor.SelectClientRandom, 0),
+				spamoor.WithClientGroup(s.options.ClientGroup),
+			)
+		})
 
-		return nil, client, wallet, err
+		return tx, client, wallet, err
 	}
 
 	return tx, client, wallet, nil


### PR DESCRIPTION
this PR improves error handling for submission errors that might occur when clients randomly go offline (private builder scenarios, with the builder being unstable).
a failed transaction could lead to a nonce gap, because the nonce check that gets triggered after submission failures failed too (client is just offline, so any request fails). with this PR, the corresponding wallet gets marked as "need nonce resync", so a nonce check is triggered before building the next transaction for the wallet.