### PR TITLE
fix panic on failed blob replacement

### DIFF
--- a/scenarios/blob-replacements/blob_replacements.go
+++ b/scenarios/blob-replacements/blob_replacements.go
@@ -400,6 +400,9 @@ func (s *Scenario) delayedReplace(ctx context.Context, txIdx uint64, tx *types.T
 	logger := s.logger
 
 	replaceTx, client, wallet, txVersion, err := s.sendBlobTx(ctx, txIdx, wallet, replacementIdx+1, tx.Nonce(), func() {})
+	if client != nil {
+		logger = logger.WithField("rpc", client.GetName())
+	}
 	if tx != nil {
 		logger = logger.WithField("nonce", tx.Nonce())
 	}
@@ -407,13 +410,13 @@ func (s *Scenario) delayedReplace(ctx context.Context, txIdx uint64, tx *types.T
 		logger = logger.WithField("wallet", s.walletPool.GetWalletName(wallet.GetAddress()))
 	}
 	if err != nil {
-		logger.WithField("rpc", client.GetName()).Warnf("blob tx %6d.%v replacement failed: %v", txIdx+1, replacementIdx+1, err)
+		logger.Warnf("blob tx %6d.%v replacement failed: %v", txIdx+1, replacementIdx+1, err)
 		return
 	}
 
 	if s.options.LogTxs {
-		logger.WithField("rpc", client.GetName()).Infof("blob tx %6d.%v sent:  %v (%v sidecars, v%v)", txIdx+1, replacementIdx+1, replaceTx.Hash().String(), len(tx.BlobTxSidecar().Blobs), txVersion)
+		logger.Infof("blob tx %6d.%v sent:  %v (%v sidecars, v%v)", txIdx+1, replacementIdx+1, replaceTx.Hash().String(), len(tx.BlobTxSidecar().Blobs), txVersion)
 	} else {
-		logger.WithField("rpc", client.GetName()).Debugf("blob tx %6d.%v sent:  %v (%v sidecars, v%v)", txIdx+1, replacementIdx+1, replaceTx.Hash().String(), len(tx.BlobTxSidecar().Blobs), txVersion)
+		logger.Debugf("blob tx %6d.%v sent:  %v (%v sidecars, v%v)", txIdx+1, replacementIdx+1, replaceTx.Hash().String(), len(tx.BlobTxSidecar().Blobs), txVersion)
 	}
 }


### PR DESCRIPTION
as seen on fusaka-devnet-3:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0xbc02b2]

goroutine 4145386 [running]:
github.com/ethpandaops/spamoor/spamoor.(*Client).GetName(0xc000e322c0?)
	/home/runner/work/spamoor/spamoor/spamoor/client.go:173 +0x12
github.com/ethpandaops/spamoor/scenarios/blob-combined.(*Scenario).delayedReplace(0xc000e322c0, {0x17a09e0, 0xc000caa000}, 0x2a2, 0xc0094ee340, 0xc000cc01e0, 0xc009e7de58, 0x2)
	/home/runner/work/spamoor/spamoor/scenarios/blob-combined/blob_combined.go:401 +0x697
created by github.com/ethpandaops/spamoor/scenarios/blob-combined.(*Scenario).sendBlobTx in goroutine 4137565
	/home/runner/work/spamoor/spamoor/scenarios/blob-combined/blob_combined.go:386 +0x1870
```