### PR TITLE
Replace deprecated release actions with softprops/action-gh-release

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -92,13 +92,34 @@ jobs:
           } catch (e) {
             console.log(e)
           }
+    # generate release artifacts
+    - name: "Generate release package: spamoor_snapshot_windows_amd64.zip"
+      run: |
+        cd spamoor_windows_amd64
+        zip -r -q ../spamoor_snapshot_windows_amd64.zip .
+    - name: "Generate release package: spamoor_snapshot_linux_amd64.tar.gz"
+      run: |
+        cd spamoor_linux_amd64
+        tar -czf ../spamoor_snapshot_linux_amd64.tar.gz .
+    - name: "Generate release package: spamoor_snapshot_linux_arm64.tar.gz"
+      run: |
+        cd spamoor_linux_arm64
+        tar -czf ../spamoor_snapshot_linux_arm64.tar.gz .
+    - name: "Generate release package: spamoor_snapshot_darwin_amd64.tar.gz"
+      run: |
+        cd spamoor_darwin_amd64
+        tar -czf ../spamoor_snapshot_darwin_amd64.tar.gz .
+    - name: "Generate release package: spamoor_snapshot_darwin_arm64.tar.gz"
+      run: |
+        cd spamoor_darwin_arm64
+        tar -czf ../spamoor_snapshot_darwin_arm64.tar.gz .
+
     - name: Create snapshot release
-      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-      id: create_release
+      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
       with:
         draft: false
         prerelease: true
-        release_name: "Dev Snapshot"
+        name: "Dev Snapshot"
         tag_name: "snapshot"
         body: |
           ## Latest automatically built executables. (Unstable development snapshot)
@@ -112,76 +133,9 @@ jobs:
           | [spamoor_snapshot_linux_arm64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/snapshot/spamoor_snapshot_linux_arm64.tar.gz) | spamoor executables for linux/arm64 |
           | [spamoor_snapshot_darwin_amd64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/snapshot/spamoor_snapshot_darwin_amd64.tar.gz) | spamoor executable for macos/amd64 |
           | [spamoor_snapshot_darwin_arm64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/snapshot/spamoor_snapshot_darwin_arm64.tar.gz) | spamoor executable for macos/arm64 |
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    # generate & upload release artifacts
-    - name: "Generate release package: spamoor_snapshot_windows_amd64.zip"
-      run: |
-        cd spamoor_windows_amd64
-        zip -r -q ../spamoor_snapshot_windows_amd64.zip .
-    - name: "Upload snapshot release artifact: spamoor_snapshot_windows_amd64.zip"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./spamoor_snapshot_windows_amd64.zip
-        asset_name: spamoor_snapshot_windows_amd64.zip
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: spamoor_snapshot_linux_amd64.tar.gz"
-      run: |
-        cd spamoor_linux_amd64
-        tar -czf ../spamoor_snapshot_linux_amd64.tar.gz .
-    - name: "Upload snapshot release artifact: spamoor_snapshot_linux_amd64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./spamoor_snapshot_linux_amd64.tar.gz
-        asset_name: spamoor_snapshot_linux_amd64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: spamoor_snapshot_linux_arm64.tar.gz"
-      run: |
-        cd spamoor_linux_arm64
-        tar -czf ../spamoor_snapshot_linux_arm64.tar.gz .
-    - name: "Upload snapshot release artifact: spamoor_snapshot_linux_arm64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./spamoor_snapshot_linux_arm64.tar.gz
-        asset_name: spamoor_snapshot_linux_arm64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: spamoor_snapshot_darwin_amd64.tar.gz"
-      run: |
-        cd spamoor_darwin_amd64
-        tar -czf ../spamoor_snapshot_darwin_amd64.tar.gz .
-    - name: "Upload snapshot release artifact: spamoor_snapshot_darwin_amd64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./spamoor_snapshot_darwin_amd64.tar.gz
-        asset_name: spamoor_snapshot_darwin_amd64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    - name: "Generate release package: spamoor_snapshot_darwin_arm64.tar.gz"
-      run: |
-        cd spamoor_darwin_arm64
-        tar -czf ../spamoor_snapshot_darwin_arm64.tar.gz .
-    - name: "Upload snapshot release artifact: spamoor_snapshot_darwin_arm64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./spamoor_snapshot_darwin_arm64.tar.gz
-        asset_name: spamoor_snapshot_darwin_arm64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+        files: |
+          spamoor_snapshot_windows_amd64.zip
+          spamoor_snapshot_linux_amd64.tar.gz
+          spamoor_snapshot_linux_arm64.tar.gz
+          spamoor_snapshot_darwin_amd64.tar.gz
+          spamoor_snapshot_darwin_arm64.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -66,14 +66,35 @@ jobs:
     - name: "Download build artifacts"
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
+    # generate release artifacts
+    - name: "Generate release package: spamoor_${{ inputs.version }}_windows_amd64.zip"
+      run: |
+        cd spamoor_windows_amd64
+        zip -r -q ../spamoor_${{ inputs.version }}_windows_amd64.zip .
+    - name: "Generate release package: spamoor_${{ inputs.version }}_linux_amd64.tar.gz"
+      run: |
+        cd spamoor_linux_amd64
+        tar -czf ../spamoor_${{ inputs.version }}_linux_amd64.tar.gz .
+    - name: "Generate release package: spamoor_${{ inputs.version }}_linux_arm64.tar.gz"
+      run: |
+        cd spamoor_linux_arm64
+        tar -czf ../spamoor_${{ inputs.version }}_linux_arm64.tar.gz .
+    - name: "Generate release package: spamoor_${{ inputs.version }}_darwin_amd64.tar.gz"
+      run: |
+        cd spamoor_darwin_amd64
+        tar -czf ../spamoor_${{ inputs.version }}_darwin_amd64.tar.gz .
+    - name: "Generate release package: spamoor_${{ inputs.version }}_darwin_arm64.tar.gz"
+      run: |
+        cd spamoor_darwin_arm64
+        tar -czf ../spamoor_${{ inputs.version }}_darwin_arm64.tar.gz .
+
     # create draft release
     - name: Create latest release
-      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-      id: create_release
+      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
       with:
         draft: true
         prerelease: false
-        release_name: "v${{ inputs.version }}"
+        name: "v${{ inputs.version }}"
         tag_name: "v${{ inputs.version }}"
         body: |
           ### Major Changes
@@ -95,76 +116,9 @@ jobs:
           | [spamoor_${{ inputs.version }}_linux_arm64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/v${{ inputs.version }}/spamoor_${{ inputs.version }}_linux_arm64.tar.gz) | spamoor executables for linux/arm64 |
           | [spamoor_${{ inputs.version }}_darwin_amd64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/v${{ inputs.version }}/spamoor_${{ inputs.version }}_darwin_amd64.tar.gz) | spamoor executable for macos/amd64 |
           | [spamoor_${{ inputs.version }}_darwin_arm64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/v${{ inputs.version }}/spamoor_${{ inputs.version }}_darwin_arm64.tar.gz) | spamoor executable for macos/arm64 |
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    # generate & upload release artifacts
-    - name: "Generate release package: spamoor_${{ inputs.version }}_windows_amd64.zip"
-      run: |
-        cd spamoor_windows_amd64
-        zip -r -q ../spamoor_${{ inputs.version }}_windows_amd64.zip .
-    - name: "Upload release artifact: spamoor_${{ inputs.version }}_windows_amd64.zip"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./spamoor_${{ inputs.version }}_windows_amd64.zip
-        asset_name: spamoor_${{ inputs.version }}_windows_amd64.zip
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: spamoor_${{ inputs.version }}_linux_amd64.tar.gz"
-      run: |
-        cd spamoor_linux_amd64
-        tar -czf ../spamoor_${{ inputs.version }}_linux_amd64.tar.gz .
-    - name: "Upload release artifact: spamoor_${{ inputs.version }}_linux_amd64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./spamoor_${{ inputs.version }}_linux_amd64.tar.gz
-        asset_name: spamoor_${{ inputs.version }}_linux_amd64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: spamoor_${{ inputs.version }}_linux_arm64.tar.gz"
-      run: |
-        cd spamoor_linux_arm64
-        tar -czf ../spamoor_${{ inputs.version }}_linux_arm64.tar.gz .
-    - name: "Upload release artifact: spamoor_${{ inputs.version }}_linux_arm64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./spamoor_${{ inputs.version }}_linux_arm64.tar.gz
-        asset_name: spamoor_${{ inputs.version }}_linux_arm64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: spamoor_${{ inputs.version }}_darwin_amd64.tar.gz"
-      run: |
-        cd spamoor_darwin_amd64
-        tar -czf ../spamoor_${{ inputs.version }}_darwin_amd64.tar.gz .
-    - name: "Upload release artifact: spamoor_${{ inputs.version }}_darwin_amd64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./spamoor_${{ inputs.version }}_darwin_amd64.tar.gz
-        asset_name: spamoor_${{ inputs.version }}_darwin_amd64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    - name: "Generate release package: spamoor_${{ inputs.version }}_darwin_arm64.tar.gz"
-      run: |
-        cd spamoor_darwin_arm64
-        tar -czf ../spamoor_${{ inputs.version }}_darwin_arm64.tar.gz .
-    - name: "Upload release artifact: spamoor_${{ inputs.version }}_darwin_arm64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./spamoor_${{ inputs.version }}_darwin_arm64.tar.gz
-        asset_name: spamoor_${{ inputs.version }}_darwin_arm64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+        files: |
+          spamoor_${{ inputs.version }}_windows_amd64.zip
+          spamoor_${{ inputs.version }}_linux_amd64.tar.gz
+          spamoor_${{ inputs.version }}_linux_arm64.tar.gz
+          spamoor_${{ inputs.version }}_darwin_amd64.tar.gz
+          spamoor_${{ inputs.version }}_darwin_arm64.tar.gz


### PR DESCRIPTION
## Summary
- Replace archived `actions/create-release@v1.1.4` and `actions/upload-release-asset@v1.0.2` with `softprops/action-gh-release@v2.6.1` in both `build-master.yml` and `build-release.yml`
- Consolidate separate create-release + upload-release-asset steps into a single action that handles both release creation and file uploads
- Fix `set-output` and Node.js 20 deprecation warnings from the archived actions

## Test plan
- [ ] Trigger a master build and verify the snapshot release is created with all 5 artifacts attached
- [ ] Trigger a release build with a test version and verify the draft release is created with correct changelog, AI release notes, and all 5 artifacts attached
- [ ] Verify release body content (artifact links, descriptions) renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)