### PR TITLE
build(deps): bump go-ethereum to glamsterdam-devnet-0 branch

### DIFF
--- a/cmd/spamoor/main.go
+++ b/cmd/spamoor/main.go
@@ -62,7 +62,7 @@ func main() {
 	flags.StringVar(&cliArgs.refillBalanceWei, "refill-balance-wei", "", "Min balance in Wei before refilling (overrides --refill-balance).")
 	flags.Uint64Var(&cliArgs.refillInterval, "refill-interval", 300, "Interval for child wallet rbalance check and refilling if needed (in sec).")
 	flags.DurationVar(&cliArgs.slotDuration, "slot-duration", 12*time.Second, "Duration of a slot/block for rate limiting (e.g., '12s', '250ms'). Use sub-second values for L2 chains.")
-	flags.Uint64Var(&cliArgs.fundingGasLimit, "funding-gas-limit", 21000, "Gas limit for wallet funding transactions (use 100000+ for L2s).")
+	flags.Uint64Var(&cliArgs.fundingGasLimit, "funding-gas-limit", 23333, "Gas limit for wallet funding transactions (use 100000+ for L2s; default clears geth's EIP-8037 110% admission margin).")
 	flags.StringArrayVar(&cliArgs.plugins, "plugin", []string{}, "Plugin tar.gz files to load (can be specified multiple times).")
 	flags.StringVar(&cliArgs.feeStrategy, "fee-strategy", "", "Fee calculation strategy: 'adaptive' for dynamic headroom with normal distribution (default: use network-suggested fees).")
 

--- a/daemon/db/schema/20250324194412_init.sql
+++ b/daemon/db/schema/20250324194412_init.sql
@@ -42,7 +42,7 @@ max_wallets: 400
 rebroadcast: 120
 base_fee: 20
 tip_fee: 2
-gas_limit: 21000
+gas_limit: 23333
 amount: 20
 data: ""
 to: ""

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/consensys/gnark-crypto v0.20.1
-	github.com/ethereum/go-ethereum v1.17.2
+	github.com/ethereum/go-ethereum v1.17.3-0.20260421080339-499762852cf2
 	github.com/fjl/geas v0.3.0
 	github.com/glebarez/go-sqlite v1.22.0
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/ethereum/c-kzg-4844/v2 v2.1.6 h1:xQymkKCT5E2Jiaoqf3v4wsNgjZLY0lRSkZn2
 github.com/ethereum/c-kzg-4844/v2 v2.1.6/go.mod h1:8HMkUZ5JRv4hpw/XUrYWSQNAUzhHMg2UDb/U+5m+XNw=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
-github.com/ethereum/go-ethereum v1.17.2 h1:ag6geu0kn8Hv5FLKTpH+Hm2DHD+iuFtuqKxEuwUsDOI=
-github.com/ethereum/go-ethereum v1.17.2/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
+github.com/ethereum/go-ethereum v1.17.3-0.20260421080339-499762852cf2 h1:PPbNu5NqmJ6+uo1y43tp1sBOt0a0S1gop5agy6qchMI=
+github.com/ethereum/go-ethereum v1.17.3-0.20260421080339-499762852cf2/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/ferranbt/fastssz v0.1.4 h1:OCDB+dYDEQDvAgtAGnTSidK1Pe2tW3nFV40XyMkTeDY=
 github.com/ferranbt/fastssz v0.1.4/go.mod h1:Ea3+oeoRGGLGm5shYAeDgu6PGUlcvQhE2fILyD9+tGg=
 github.com/fjl/geas v0.3.0 h1:ijWKIchZx8teIGD1wJU5SiIELgMOUZyc5TAibzxMpao=

--- a/scenarios/blob-average/blobaverage.go
+++ b/scenarios/blob-average/blobaverage.go
@@ -418,7 +418,7 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64) (scenario.Recei
 		GasFeeCap:  uint256.MustFromBig(feeCap),
 		GasTipCap:  uint256.MustFromBig(tipCap),
 		BlobFeeCap: uint256.MustFromBig(blobFee),
-		Gas:        21000,
+		Gas:        23333,
 		To:         &toAddr,
 		Value:      uint256.NewInt(0),
 	}, blobRefs)

--- a/scenarios/blob-combined/blob_combined.go
+++ b/scenarios/blob-combined/blob_combined.go
@@ -315,7 +315,7 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64, wallet *spamoor
 		GasFeeCap:  uint256.MustFromBig(feeCap),
 		GasTipCap:  uint256.MustFromBig(tipCap),
 		BlobFeeCap: uint256.MustFromBig(blobFee),
-		Gas:        21000,
+		Gas:        23333,
 		To:         &toAddr,
 		Value:      uint256.NewInt(0),
 	}, blobRefs)

--- a/scenarios/blob-conflicting/blob_conflicting.go
+++ b/scenarios/blob-conflicting/blob_conflicting.go
@@ -296,7 +296,7 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64) (scenario.Recei
 		GasFeeCap:  uint256.MustFromBig(feeCap),
 		GasTipCap:  uint256.MustFromBig(tipCap),
 		BlobFeeCap: uint256.MustFromBig(blobFee),
-		Gas:        21000,
+		Gas:        23333,
 		To:         &toAddr,
 		Value:      uint256.NewInt(0),
 	}, blobRefs)
@@ -306,7 +306,7 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64) (scenario.Recei
 	normalTx, err := txbuilder.DynFeeTx(&txbuilder.TxMetadata{
 		GasFeeCap: uint256.MustFromBig(feeCap),
 		GasTipCap: uint256.MustFromBig(tipCap),
-		Gas:       21000,
+		Gas:       23333,
 		To:        &toAddr,
 		Value:     uint256.NewInt(0),
 	})

--- a/scenarios/blob-replacements/blob_replacements.go
+++ b/scenarios/blob-replacements/blob_replacements.go
@@ -315,7 +315,7 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64, wallet *spamoor
 		GasFeeCap:  uint256.MustFromBig(feeCap),
 		GasTipCap:  uint256.MustFromBig(tipCap),
 		BlobFeeCap: uint256.MustFromBig(blobFee),
-		Gas:        21000,
+		Gas:        23333,
 		To:         &toAddr,
 		Value:      uint256.NewInt(0),
 	}, blobRefs)

--- a/scenarios/blobs/blobs.go
+++ b/scenarios/blobs/blobs.go
@@ -294,7 +294,7 @@ func (s *Scenario) sendBlobTx(ctx context.Context, txIdx uint64) (scenario.Recei
 		GasFeeCap:  uint256.MustFromBig(feeCap),
 		GasTipCap:  uint256.MustFromBig(tipCap),
 		BlobFeeCap: uint256.MustFromBig(blobFee),
-		Gas:        21000,
+		Gas:        23333,
 		To:         &toAddr,
 		Value:      uint256.NewInt(0),
 	}, blobRefs)

--- a/scenarios/eoatx/eoatx.go
+++ b/scenarios/eoatx/eoatx.go
@@ -56,7 +56,7 @@ var ScenarioDefaultOptions = ScenarioOptions{
 	Rebroadcast:  1,
 	BaseFee:      20,
 	TipFee:       2,
-	GasLimit:     21000,
+	GasLimit:     23333,
 	Amount:       20,
 	Data:         "",
 	To:           "",

--- a/spammer-configs/statebloat-basics.yaml
+++ b/spammer-configs/statebloat-basics.yaml
@@ -31,7 +31,7 @@
     base_fee: 20
     client_group: ""
     data: ""
-    gas_limit: 21000
+    gas_limit: 23333
     log_txs: false
     max_pending: 10000
     max_wallets: 5000

--- a/spamoor/wallet.go
+++ b/spamoor/wallet.go
@@ -728,7 +728,7 @@ func (wallet *Wallet) BuildFillerTx(nonce uint64, gasTipCap, gasFeeCap *big.Int)
 		Nonce:     nonce,
 		GasTipCap: gasTipCap,
 		GasFeeCap: gasFeeCap,
-		Gas:       21000, // Minimum gas for simple transfer
+		Gas:       23333, // 21000 intrinsic + geth EIP-8037 110% txpool margin
 		To:        &wallet.address,
 		Value:     big.NewInt(0),
 		Data:      nil,

--- a/spamoor/walletpool.go
+++ b/spamoor/walletpool.go
@@ -267,10 +267,13 @@ func (pool *WalletPool) SetFundingGasLimit(gasLimit uint64) {
 	pool.config.FundingGasLimit = gasLimit
 }
 
-// GetFundingGasLimit returns the gas limit for funding transactions, defaulting to 21000.
+// GetFundingGasLimit returns the gas limit for funding transactions, defaulting to 23333.
+// This clears geth's EIP-8037 110% intrinsic-gas admission margin
+// (ceil(21000 * 10/9) = 23333) on chains where gasCostPerStateByte != 0, and is a
+// no-op overhead on chains without the rule.
 func (pool *WalletPool) GetFundingGasLimit() uint64 {
 	if pool.config.FundingGasLimit == 0 {
-		return 21000
+		return 23333
 	}
 	return pool.config.FundingGasLimit
 }

--- a/webui/handlers/api/api.go
+++ b/webui/handlers/api/api.go
@@ -2165,7 +2165,7 @@ func (ah *APIHandler) SendTransaction(w http.ResponseWriter, r *http.Request) {
 		if len(calldata) > 0 {
 			gasLimit = 100000 // Higher limit for contract calls
 		} else {
-			gasLimit = 21000 // Standard transfer
+			gasLimit = 23333 // Standard transfer (clears geth EIP-8037 110% admission margin)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Bumps `github.com/ethereum/go-ethereum` from `v1.17.2` to the tip of the [`glamsterdam-devnet-0`](https://github.com/ethereum/go-ethereum/tree/glamsterdam-devnet-0) branch (commit `499762852cf2`, resolved as pseudo-version `v1.17.3-0.20260421080339-499762852cf2`).
- Lets spamoor exercise upcoming Glamsterdam-fork changes against its matching devnet.

## Notes
- Go modules pin to a commit, not a branch. To pull newer commits from `glamsterdam-devnet-0` later, rerun `go get github.com/ethereum/go-ethereum@glamsterdam-devnet-0 && go mod tidy`.

## Test plan
- [x] `go build -tags "with_blob_v1,ckzg" ./...`
- [x] `go vet -tags "with_blob_v1,ckzg" ./...`
- [x] `gofmt -l .` (clean)
- [ ] CI green
- [ ] Smoke-test against a glamsterdam-devnet-0 node