### PR TITLE
spamoor: use cpsbFloor when head block not yet observed

### DIFF
--- a/spamoor/txpool.go
+++ b/spamoor/txpool.go
@@ -1591,6 +1591,18 @@ func (pool *TxPool) IsAmsterdam() bool {
 	return pool.isAmsterdam
 }
 
+// HasObservedHead reports whether the pool has loaded or processed at least
+// one head block (via initBlockStats or processBlock). Callers that need to
+// distinguish "chain state not yet known" from "chain is confirmed
+// pre-Amsterdam" should gate on this in addition to IsAmsterdam. Returns
+// false during the startup window when initBlockStats failed (e.g. no client
+// available yet) and no block has been processed.
+func (pool *TxPool) HasObservedHead() bool {
+	pool.blockStatsMutex.RLock()
+	defer pool.blockStatsMutex.RUnlock()
+	return pool.currentGasLimit > 0
+}
+
 // GetCostPerStateByte returns the current EIP-8037 cost_per_state_byte,
 // computed from the latest observed block gas limit. Returns 0 pre-Amsterdam
 // or before the first block has been seen.

--- a/spamoor/walletpool.go
+++ b/spamoor/walletpool.go
@@ -295,11 +295,19 @@ func (pool *WalletPool) SetFundingGasLimit(gasLimit uint64) {
 // Amsterdam: 21,000 + (112·cpsb if empty) + 10% buffer, covering both the
 // EIP-2780 intrinsic state-gas charge on empty recipients and the txpool's
 // 110% intrinsic-regular check.
+//
+// Startup race: on a chain where Amsterdam is active at genesis, IsAmsterdam
+// is false until the first block is observed. If funding runs before that,
+// cpsb is 0 and we'd fall back to pre-Amsterdam sizing — producing txs whose
+// gas limit is far below the node's actual intrinsic charge. We instead use
+// cpsbFloor (the hardcoded devnet value) whenever we haven't yet observed a
+// head block, so worst-case on a truly pre-Amsterdam chain we simply
+// over-reserve gas until the first block confirms pre-Amsterdam state.
 func (pool *WalletPool) FundingGasFor(isEmpty bool) uint64 {
 	if pool.config.FundingGasLimit != 0 {
 		return pool.config.FundingGasLimit
 	}
-	cpsb := pool.txpool.GetCostPerStateByte()
+	cpsb := pool.effectiveCpsb()
 	if cpsb == 0 {
 		return 21_000
 	}
@@ -320,12 +328,13 @@ func (pool *WalletPool) GetFundingGasLimit() uint64 {
 // batcherGasFor returns the per-recipient gas contribution for a single
 // funding request inside the batcher contract. Honors an explicit
 // SetFundingGasLimit override when it exceeds BatcherDefaultGasPerTx;
-// otherwise computes from live chain state.
+// otherwise computes from live chain state. See FundingGasFor for the
+// startup-race handling via effectiveCpsb.
 func (pool *WalletPool) batcherGasFor(req *FundingRequest) uint64 {
 	if pool.config.FundingGasLimit > BatcherDefaultGasPerTx {
 		return pool.config.FundingGasLimit
 	}
-	cpsb := pool.txpool.GetCostPerStateByte()
+	cpsb := pool.effectiveCpsb()
 	if cpsb == 0 {
 		return BatcherDefaultGasPerTx
 	}
@@ -338,12 +347,29 @@ func (pool *WalletPool) batcherGasFor(req *FundingRequest) uint64 {
 
 // batcherBaseGas returns the per-batch overhead (tx intrinsic + batcher
 // dispatch). On Amsterdam the baseline must also cover the 110% txpool buffer
-// on the 21,000 regular intrinsic, so we bump from 50k to 65k.
+// on the 21,000 regular intrinsic, so we bump from 50k to 65k. If the head
+// block hasn't been observed yet, we conservatively assume Amsterdam to avoid
+// under-reserving on genesis-Amsterdam chains (see FundingGasFor).
 func (pool *WalletPool) batcherBaseGas() uint64 {
-	if !pool.txpool.IsAmsterdam() {
-		return BatcherBaseGas
+	if pool.txpool.IsAmsterdam() || !pool.txpool.HasObservedHead() {
+		return 65_000
 	}
-	return 65_000
+	return BatcherBaseGas
+}
+
+// effectiveCpsb returns the cost-per-state-byte to use when sizing funding
+// transactions. It returns the live value when Amsterdam activation is known,
+// falls back to cpsbFloor when the head block has not been observed yet (to
+// guard the genesis-Amsterdam startup race), and returns 0 only when the
+// chain is confirmed pre-Amsterdam.
+func (pool *WalletPool) effectiveCpsb() uint64 {
+	if cpsb := pool.txpool.GetCostPerStateByte(); cpsb != 0 {
+		return cpsb
+	}
+	if !pool.txpool.HasObservedHead() {
+		return cpsbFloor
+	}
+	return 0
 }
 
 // packFundingBatches greedily groups funding requests into batcher calls so


### PR DESCRIPTION
## Summary

Close a startup-race in the Amsterdam-aware funding sizing paths.

`FundingGasFor`, `batcherGasFor`, and `batcherBaseGas` all fall back to pre-Amsterdam sizing when `GetCostPerStateByte()` returns `0` / `IsAmsterdam()` is `false`. Both signals are driven by the first observed head block:

- `initBlockStats()` fetches the head eagerly at `NewTxPool`, but it requires a non-builder client from the pool (`WithoutBuilder()`) and logs `initial head block load failed, falling back to lazy init` whenever the client pool hasn't finished its first health check. On ePBS / builder setups the "non-builder" subset can briefly be empty.
- Otherwise `isAmsterdam` and `currentGasLimit` only get populated when `processBlock` runs — after the first block is gossiped in.

If scenario startup, root-wallet funding, or a WebUI-driven send happens inside that window on a chain where Amsterdam is active at genesis, the fallback fires even though the node will charge full EIP-8037 state gas at intrinsic time:

- `FundingGasFor` returns `21_000` → direct funding tx to an empty target is short of the node's intrinsic (`21k + 112·cpsb`).
- `batcherGasFor` returns `BatcherDefaultGasPerTx` (35k) → packer crams ~`16M / 35k ≈ 457` recipients into one batcher tx. Actual state gas on the devnet (`cpsb=1174`) is `~132k` per empty recipient, so the tx demands well over the 60M block gas limit and cannot land. On a bal-devnet-3 geth this also tickles a BAL-on-skipped-tx divergence that halts the chain.
- `batcherBaseGas` returns `BatcherBaseGas` (50k) instead of `65k`, underreserving the 10/9 buffer.

### Fix

Add `TxPool.HasObservedHead()` to distinguish "chain state not yet known" from "chain is confirmed pre-Amsterdam". Introduce `WalletPool.effectiveCpsb()` that returns live cpsb when known, `cpsbFloor` (1174) when the head hasn't been observed, and `0` only when confirmed pre-Amsterdam. Route `FundingGasFor`, `batcherGasFor`, and `batcherBaseGas` through it.

On a truly pre-Amsterdam chain the behavior is unchanged after the first block lands. If the race window is entered on a pre-Amsterdam chain, we over-reserve gas until the first processed block confirms it — no correctness loss, just more batcher txs for the initial fund-out.

### Why this came up

Reproduced on ethereum-package ePBS devnet (`glamsterdam-devnet-0` geth + `v1.7.0-alpha.5-minimal` prysm) at `gloas_fork_epoch: 0`: `initBlockStats` logged `no non-builder client available`, funding ran before the first block was processed, the batcher packer used pre-Amsterdam sizing, and the chain halted at block 3 with repeating `invalid block access list: mismatch between local/remote access list for state accesses` on every EL. A separate geth issue covers the BAL divergence; this PR removes the spamoor-side trigger.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (no package-level tests exist)
- [ ] Re-run the epbs kurtosis devnet with `eoatx throughput: 100` and a large enough child-wallet pool to exercise the funding batcher; confirm no oversized batcher tx is produced and the packer splits 1000 recipients into ~11 batches sized for `cpsb=1174` instead of one 450+ recipient tx.
- [ ] Verify behavior unchanged on a pre-Amsterdam chain (e.g. current public testnets) once the first block has been processed.