### PR TITLE
spamoor: fix effectiveCpsb fork-boundary race

### DIFF
--- a/spamoor/walletpool.go
+++ b/spamoor/walletpool.go
@@ -358,18 +358,29 @@ func (pool *WalletPool) batcherBaseGas() uint64 {
 }
 
 // effectiveCpsb returns the cost-per-state-byte to use when sizing funding
-// transactions. It returns the live value when Amsterdam activation is known,
-// falls back to cpsbFloor when the head block has not been observed yet (to
-// guard the genesis-Amsterdam startup race), and returns 0 only when the
-// chain is confirmed pre-Amsterdam.
+// transactions. It returns the live value when Amsterdam activation is known
+// from a streamed post-Amsterdam block; otherwise falls back to cpsbFloor.
+//
+// The previous "head observed AND head is pre-Amsterdam → return 0" path was
+// racy at the fork boundary: observing a pre-Amsterdam head at time T does
+// not prove the chain is pre-Amsterdam at time T+ε. Amsterdam can activate
+// between blocks, and the pre-existing latest-observed-block snapshot stays
+// stale until processBlock receives the first post-Amsterdam block via the
+// external block subscription. During that window (empirically 5–35s of
+// CL→EL→spamoor lag) funding txs were sized at 21,000 gas while ELs already
+// enforced post-EIP-8037 admission (e.g. geth's 110% intrinsic-regular
+// buffer rejects 21,000 with "minimum needed 23,333").
+//
+// EIP-8037 fixes cost_per_state_byte at cpsbFloor (=1174), so the only cost
+// of unifying the uncertain branches is over-reserving on a chain that turns
+// out to be pre-Amsterdam — already documented as acceptable for the
+// no-head startup case. Callers that genuinely need pre-Amsterdam sizing
+// can pin via SetFundingGasLimit.
 func (pool *WalletPool) effectiveCpsb() uint64 {
 	if cpsb := pool.txpool.GetCostPerStateByte(); cpsb != 0 {
 		return cpsb
 	}
-	if !pool.txpool.HasObservedHead() {
-		return cpsbFloor
-	}
-	return 0
+	return cpsbFloor
 }
 
 // packFundingBatches greedily groups funding requests into batcher calls so


### PR DESCRIPTION
## Summary

Drops the racy `observed pre-Amsterdam head → return 0` branch in `WalletPool.effectiveCpsb()`. Observing a pre-Amsterdam head at time T does not prove the chain is pre-Amsterdam at time T+ε — Amsterdam can activate between blocks, and the latest-observed-block snapshot stays stale until `processBlock` receives the first post-Amsterdam block via the external block subscription.

Empirically the CL→EL→spamoor lag at the fork boundary is 5-35 seconds. During that window, funding txs were sized at 21,000 gas while ELs already enforced post-EIP-8037 admission rules. Geth's tx pool rejects with `intrinsic gas too low: gas 21000, minimum needed 23333` (110% of intrinsic regular gas, applied when `gasCostPerStateByte != 0`).

This was reproducible on bal-devnet-4 (Gloas at epoch 2, minimal preset → fork boundary very close to genesis). Five separate test runs hit the race at different lag values.

## Fix

Drop path C — when `GetCostPerStateByte()` returns 0, fall through to `cpsbFloor` unconditionally. EIP-8037 fixes `cost_per_state_byte` at `cpsbFloor=1174`, so this is exact for any post-Amsterdam state. The cost on a confirmed pre-Amsterdam chain is over-reserving funding gas — the same tradeoff PR #218 already accepted for the no-head startup case (\"worst-case on a truly pre-Amsterdam chain we simply over-reserve gas... no correctness loss\"). This change unifies the two branches symmetrically.

Callers that genuinely need pre-Amsterdam sizing can pin via `SetFundingGasLimit`.

## Test plan
- [x] Reproduces on bal-devnet-4: assertoor `bal-devnet-4-eels-tests.yaml` playbook funding step fails 5/5 against geth pre-fix.
- [x] Passes on bal-devnet-4 with the fix: funding tx submitted before Amsterdam flip (Δt = 2s) succeeds; `initialized 1 child wallets` in 8s.
- [x] No behavioral change on a confirmed post-Amsterdam chain (path A still returns the live cpsb).
- [ ] Unit test for the race window (left for upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)