### PR TITLE
ci: drop macos/amd64 release builds

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -141,39 +141,6 @@ jobs:
         path: ./bin/*
         name: spamoor_windows_amd64
 
-  build_darwin_amd64_binary:
-    name: Build macos/amd64 binary
-    runs-on: macos-15-intel
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
-
-    # setup global dependencies
-    - name: Set up go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version: 1.25.x
-
-    # setup project dependencies
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-
-    # build binaries
-    - name: Build macos amd64 binary
-      run: |
-        make build
-      env:
-        RELEASE: ${{ inputs.release }}
-
-    # upload artifacts
-    - name: "Upload artifact: spamoor_darwin_amd64"
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        path: ./bin/*
-        name: spamoor_darwin_amd64
-
   build_darwin_arm64_binary:
     name: Build macos/arm64 binary
     runs-on: macos-26

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -105,10 +105,6 @@ jobs:
       run: |
         cd spamoor_linux_arm64
         tar -czf ../spamoor_snapshot_linux_arm64.tar.gz .
-    - name: "Generate release package: spamoor_snapshot_darwin_amd64.tar.gz"
-      run: |
-        cd spamoor_darwin_amd64
-        tar -czf ../spamoor_snapshot_darwin_amd64.tar.gz .
     - name: "Generate release package: spamoor_snapshot_darwin_arm64.tar.gz"
       run: |
         cd spamoor_darwin_arm64
@@ -131,11 +127,9 @@ jobs:
           | [spamoor_snapshot_windows_amd64.zip](https://github.com/ethpandaops/spamoor/releases/download/snapshot/spamoor_snapshot_windows_amd64.zip) | spamoor executables for windows/amd64 |
           | [spamoor_snapshot_linux_amd64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/snapshot/spamoor_snapshot_linux_amd64.tar.gz) | spamoor executables for linux/amd64 |
           | [spamoor_snapshot_linux_arm64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/snapshot/spamoor_snapshot_linux_arm64.tar.gz) | spamoor executables for linux/arm64 |
-          | [spamoor_snapshot_darwin_amd64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/snapshot/spamoor_snapshot_darwin_amd64.tar.gz) | spamoor executable for macos/amd64 |
           | [spamoor_snapshot_darwin_arm64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/snapshot/spamoor_snapshot_darwin_arm64.tar.gz) | spamoor executable for macos/arm64 |
         files: |
           spamoor_snapshot_windows_amd64.zip
           spamoor_snapshot_linux_amd64.tar.gz
           spamoor_snapshot_linux_arm64.tar.gz
-          spamoor_snapshot_darwin_amd64.tar.gz
           spamoor_snapshot_darwin_arm64.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -79,10 +79,6 @@ jobs:
       run: |
         cd spamoor_linux_arm64
         tar -czf ../spamoor_${{ inputs.version }}_linux_arm64.tar.gz .
-    - name: "Generate release package: spamoor_${{ inputs.version }}_darwin_amd64.tar.gz"
-      run: |
-        cd spamoor_darwin_amd64
-        tar -czf ../spamoor_${{ inputs.version }}_darwin_amd64.tar.gz .
     - name: "Generate release package: spamoor_${{ inputs.version }}_darwin_arm64.tar.gz"
       run: |
         cd spamoor_darwin_arm64
@@ -114,11 +110,9 @@ jobs:
           | [spamoor_${{ inputs.version }}_windows_amd64.zip](https://github.com/ethpandaops/spamoor/releases/download/v${{ inputs.version }}/spamoor_${{ inputs.version }}_windows_amd64.zip) | spamoor executables for windows/amd64 |
           | [spamoor_${{ inputs.version }}_linux_amd64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/v${{ inputs.version }}/spamoor_${{ inputs.version }}_linux_amd64.tar.gz) | spamoor executables for linux/amd64 |
           | [spamoor_${{ inputs.version }}_linux_arm64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/v${{ inputs.version }}/spamoor_${{ inputs.version }}_linux_arm64.tar.gz) | spamoor executables for linux/arm64 |
-          | [spamoor_${{ inputs.version }}_darwin_amd64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/v${{ inputs.version }}/spamoor_${{ inputs.version }}_darwin_amd64.tar.gz) | spamoor executable for macos/amd64 |
           | [spamoor_${{ inputs.version }}_darwin_arm64.tar.gz](https://github.com/ethpandaops/spamoor/releases/download/v${{ inputs.version }}/spamoor_${{ inputs.version }}_darwin_arm64.tar.gz) | spamoor executable for macos/arm64 |
         files: |
           spamoor_${{ inputs.version }}_windows_amd64.zip
           spamoor_${{ inputs.version }}_linux_amd64.tar.gz
           spamoor_${{ inputs.version }}_linux_arm64.tar.gz
-          spamoor_${{ inputs.version }}_darwin_amd64.tar.gz
           spamoor_${{ inputs.version }}_darwin_arm64.tar.gz


### PR DESCRIPTION
## Summary
- Remove the `build_darwin_amd64_binary` job from the shared build workflow
- Drop the darwin_amd64 tarball steps, release-notes table row, and files entry from snapshot/release workflows
- Mac builds are now arm64-only

## Test plan
- [ ] Trigger snapshot build and confirm artifacts contain only windows_amd64, linux_amd64, linux_arm64, darwin_arm64
- [ ] On the next tagged release, confirm artifacts and release-notes table match