### PR TITLE
[codex] fix security alerts

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -3,10 +3,6 @@ name: Reusable build workflow
 on:
   workflow_call:
     inputs:
-      ref:
-        description: 'The branch, tag or SHA to build'
-        required: true
-        type: string
       release:
         description: 'Release version tag for this build'
         default: ''
@@ -15,7 +11,7 @@ on:
       docker:
         description: 'Build docker images'
         default: false
-        required: true
+        required: false
         type: boolean
       docker_repository:
         description: 'Docker Hub Repository'
@@ -40,22 +36,25 @@ on:
         description: 'Docker Hub Token'
         required: false
 
+permissions:
+  contents: read
+
 # shared build jobs
 jobs:
   build_linux_amd64_binary:
     name: Build linux/amd64 binary
     runs-on: ubuntu-latest
+    outputs:
+      artifact_id: ${{ steps.upload_binary.outputs.artifact-id }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.25.x
-    
+
     # setup project dependencies
     - name: Get dependencies
       run: |
@@ -70,18 +69,19 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: spamoor_linux_amd64"
+      id: upload_binary
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         path: ./bin/*
         name: spamoor_linux_amd64
-  
+
   build_linux_arm64_binary:
     name: Build linux/arm64 binary
     runs-on: ubuntu-24.04-arm
+    outputs:
+      artifact_id: ${{ steps.upload_binary.outputs.artifact-id }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
@@ -103,6 +103,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: spamoor_linux_arm64"
+      id: upload_binary
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         path: ./bin/*
@@ -113,8 +114,6 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
@@ -146,8 +145,6 @@ jobs:
     runs-on: macos-26
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
@@ -181,8 +178,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     - name: Get build version
       id: vars
@@ -201,7 +196,8 @@ jobs:
     - name: Download build artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: spamoor_linux_amd64
+        artifact-ids: ${{ needs.build_linux_amd64_binary.outputs.artifact_id }}
+        merge-multiple: true
         path: ./bin
 
     # prepare environment
@@ -209,7 +205,7 @@ jobs:
       run: |
         chmod +x ./bin/*
         ls -lach ./bin
-    
+
     # build amd64 image
     - name: Build amd64 docker image
       run: |
@@ -221,7 +217,7 @@ jobs:
       run: |
         docker push ${{ inputs.docker_repository }}:${{ inputs.docker_tag_prefix }}-amd64
         docker push ${{ inputs.docker_repository }}:${{ inputs.docker_tag_prefix }}-${{ steps.vars.outputs.sha_short }}-amd64
-  
+
   build_arm64_docker_image:
     name: Build arm64 docker image
     needs: [build_linux_arm64_binary]
@@ -229,8 +225,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
     - name: Get build version
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -248,7 +242,8 @@ jobs:
     - name: Download build artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: spamoor_linux_arm64
+        artifact-ids: ${{ needs.build_linux_arm64_binary.outputs.artifact_id }}
+        merge-multiple: true
         path: ./bin
 
     # prepare environment
@@ -256,7 +251,7 @@ jobs:
       run: |
         chmod +x ./bin/*
         ls -lach ./bin
-    
+
     # build arm64 image
     - name: Build arm64 docker image
       run: |
@@ -276,8 +271,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
     - name: Get build version
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -290,7 +283,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    
+
     # build multiarch image
     - name: Build multiarch docker manifest
       run: |
@@ -308,8 +301,6 @@ jobs:
         tag: ${{ fromJSON(inputs.additional_tags) }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
     - name: Get build version
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -322,7 +313,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    
+
     # build multiarch image
     - name: "Build additional docker manifest: ${{ matrix.tag }}"
       run: |

--- a/.github/workflows/_shared-check.yaml
+++ b/.github/workflows/_shared-check.yaml
@@ -2,12 +2,9 @@
 name: Reusable check workflow
 on:
   workflow_call:
-    inputs:
-      ref:
-        description: "Git ref to checkout (defaults to event's default ref)"
-        type: string
-        required: false
-        default: ''
+
+permissions:
+  contents: read
 
 # shared check jobs
 jobs:
@@ -16,15 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.25.x
-    
+
     - name: Verify dependencies
       run: go mod verify
 

--- a/.github/workflows/build-dev-latest.yml
+++ b/.github/workflows/build-dev-latest.yml
@@ -22,7 +22,6 @@ jobs:
     needs: [check_source]
     uses: ./.github/workflows/_shared-build.yaml
     with:
-      ref: ${{ github.sha }}
       release: "snapshot"
       docker: true
       docker_repository: "ethpandaops/spamoor"

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -2,7 +2,7 @@
 name: Build PR
 
 on:
-  pull_request_target:
+  pull_request:
     types: [synchronize]
   workflow_dispatch:
     inputs:
@@ -14,51 +14,55 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   prinfo:
     name: "Get PR info"
     runs-on: ubuntu-latest
     outputs:
       run_builds: ${{ steps.loadinfo.outputs.run_builds }}
-      commit_ref: ${{ steps.loadinfo.outputs.commit_ref }}
       build_docker: ${{ steps.loadinfo.outputs.build_docker }}
       docker_tag: ${{ steps.loadinfo.outputs.docker_tag }}
     steps:
     - name: "Load PR info"
       id: loadinfo
+      env:
+        HAS_DOCKER_IMAGE_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-docker-image') }}
+        SAME_REPOSITORY_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        MANUAL_DOCKER_TAG: ${{ inputs.docker_tag }}
       run: |
-        has_docker_image_label="${{ contains(github.event.pull_request.labels.*.name, 'build-docker-image') }}"
+        has_docker_image_label="$HAS_DOCKER_IMAGE_LABEL"
+        same_repository_pr="$SAME_REPOSITORY_PR"
         run_builds="$has_docker_image_label"
+        build_docker="false"
         echo "docker image label: $has_docker_image_label"
+        echo "same repository PR: $same_repository_pr"
 
         branch_name="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
         branch_name="$(echo "$branch_name" | sed 's/\//-/g')"
         echo "branch name: $branch_name"
 
-        commit_repo="$GITHUB_REPOSITORY"
-        commit_ref="${{ github.event.pull_request.head.sha }}"
-        if [[ -z "$commit_ref" ]]; then
-          commit_ref="${{ github.sha }}"
-        fi
-        
-        echo "repository: $commit_repo"
-        echo "commit: $commit_ref"
-        
-        manual_tag="${{ inputs.docker_tag }}"
+        manual_tag="$MANUAL_DOCKER_TAG"
         if [[ ! -z "$manual_tag" ]]; then
-          has_docker_image_label="true"
           branch_name="$manual_tag"
           run_builds="true"
+          build_docker="true"
+        elif [[ "$has_docker_image_label" == "true" ]] && [[ "$same_repository_pr" == "true" ]]; then
+          build_docker="true"
+        elif [[ "$has_docker_image_label" == "true" ]]; then
+          echo "Skipping docker push for forked PR; dispatch this workflow manually to publish a trusted build."
         fi
 
         if [[ "$branch_name" == "master" ]] || [[ "$branch_name" =~ ^v[0-9] ]]; then
           echo "Invalid branch name! Skipping builds"
           run_builds="false"
+          build_docker="false"
         fi
 
         echo "run_builds=$run_builds" >> $GITHUB_OUTPUT
-        echo "commit_ref=$commit_ref" >> $GITHUB_OUTPUT
-        echo "build_docker=$has_docker_image_label" >> $GITHUB_OUTPUT
+        echo "build_docker=$build_docker" >> $GITHUB_OUTPUT
         echo "docker_tag=$branch_name" >> $GITHUB_OUTPUT
 
   check_source:
@@ -70,11 +74,21 @@ jobs:
   build_binaries:
     name: "Build Spamoor"
     needs: [prinfo, check_source]
-    if: ${{ needs.prinfo.outputs.run_builds == 'true' }}
+    if: ${{ needs.prinfo.outputs.run_builds == 'true' && needs.prinfo.outputs.build_docker != 'true' }}
     uses: ./.github/workflows/_shared-build.yaml
     with:
-      ref: ${{ needs.prinfo.outputs.commit_ref }}
-      docker: ${{ needs.prinfo.outputs.build_docker == 'true' }}
+      docker: false
+      docker_repository: "ethpandaops/spamoor"
+      docker_tag_prefix: ${{needs.prinfo.outputs.docker_tag}}
+      additional_tags: "['${{needs.prinfo.outputs.docker_tag}}','${{needs.prinfo.outputs.docker_tag}}-latest']"
+
+  build_binaries_and_docker:
+    name: "Build Spamoor and Docker image"
+    needs: [prinfo, check_source]
+    if: ${{ needs.prinfo.outputs.run_builds == 'true' && needs.prinfo.outputs.build_docker == 'true' }}
+    uses: ./.github/workflows/_shared-build.yaml
+    with:
+      docker: true
       docker_repository: "ethpandaops/spamoor"
       docker_tag_prefix: ${{needs.prinfo.outputs.docker_tag}}
       additional_tags: "['${{needs.prinfo.outputs.docker_tag}}','${{needs.prinfo.outputs.docker_tag}}-latest']"

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -25,7 +25,6 @@ jobs:
     needs: [check_source]
     uses: ./.github/workflows/_shared-build.yaml
     with:
-      ref: ${{ github.sha }}
       release: "snapshot"
       docker: true
       docker_repository: "ethpandaops/spamoor"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,7 +16,6 @@ jobs:
     name: "Build Spamoor"
     uses: ./.github/workflows/_shared-build.yaml
     with:
-      ref: ${{ github.sha }}
       release: "v${{ inputs.version }}"
       docker: true
       docker_repository: "ethpandaops/spamoor"

--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -53,5 +53,3 @@ jobs:
     needs: [update-symbols]
     if: github.actor == 'dependabot[bot]' && needs.update-symbols.outputs.symbols_updated == 'true'
     uses: ./.github/workflows/_shared-check.yaml
-    with:
-      ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check_source:
     name: "Run code checks"


### PR DESCRIPTION
## Summary

Mirrors the workflow hardening landed in ethpandaops/assertoor#183.

- Drops caller-controlled `ref` inputs from reusable check/build workflows so reusable jobs check out the event SHA instead of arbitrary PR-provided refs.
- Moves the PR build workflow (`build-dev.yml`) from `pull_request_target` to `pull_request` and adds explicit read-only default permissions.
- Splits PR binary builds from Docker publishing so fork PRs do not receive DockerHub secrets, while same-repository / manual trusted Docker publishing remains available.
- Adds explicit workflow permissions and switches internal artifact handoffs (linux amd64/arm64 binaries → docker jobs) to artifact IDs to avoid artifact-name poisoning.
- Drops the now-orphan `with: ref:` from `dependabot-fix.yml`'s reusable-check invocation. That workflow remains on `pull_request_target` (gated by `github.actor == 'dependabot[bot]'`) so it can still push regenerated symbols back to dependabot PRs.

## Validation

- `actionlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)