### PR TITLE
Add blob-average (~3 blobs/block) to the Regular Chain Load group

### DIFF
--- a/daemon/db/schema/20260615120000_regular_group_blobavg.sql
+++ b/daemon/db/schema/20260615120000_regular_group_blobavg.sql
@@ -1,0 +1,44 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Default-enable the "Regular Chain Load" group so it runs on launch. Group rows
+-- are never executed directly; their members self-resume by their own status, so
+-- we flip the member rows (group_id = 10) to running (status 1). The group row
+-- itself (id 10) stays status 0.
+UPDATE "spammers" SET "status" = 1 WHERE "group_id" = 10;
+
+-- Add a blob-average member targeting an average of 3 blobs/block. blob-average
+-- is driven by target_average (not throughput), so it joins with weight 0: it
+-- takes no share of the group's shared-throughput budget and simply runs at its
+-- own target average alongside the other members.
+INSERT INTO "spammers" ("id", "scenario", "name", "description", "config", "status", "created_at", "state", "group_id", "group_config")
+VALUES
+(30, 'blob-average', 'Blob Average', 'Maintains a steady average of ~3 blobs per block.', '# wallet settings
+seed: blobaverage-700004 # seed for the wallet
+refill_amount: 5000000000000000000 # refill 5 ETH when
+refill_balance: 1000000000000000000 # balance drops below 1 ETH
+refill_interval: 600 # check every 10 minutes
+
+# scenario: blob-average
+target_average: 3
+sidecars: 1
+max_pending: 10
+max_wallets: 5
+rebroadcast: 1
+base_fee: 20
+tip_fee: 2
+blob_fee: 20
+client_group: ""
+log_txs: false
+
+', 1, 0, '{}', 10, '{"weight": 0, "enabled": true, "sort_order": 9}');
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DELETE FROM "spammers" WHERE "id" = 30 AND "group_id" = 10;
+UPDATE "spammers" SET "status" = 0 WHERE "group_id" = 10;
+
+-- +goose StatementEnd

--- a/daemon/db/schema/20260615120000_regular_group_blobavg.sql
+++ b/daemon/db/schema/20260615120000_regular_group_blobavg.sql
@@ -1,16 +1,12 @@
 -- +goose Up
 -- +goose StatementBegin
 
--- Default-enable the "Regular Chain Load" group so it runs on launch. Group rows
--- are never executed directly; their members self-resume by their own status, so
--- we flip the member rows (group_id = 10) to running (status 1). The group row
--- itself (id 10) stays status 0.
-UPDATE "spammers" SET "status" = 1 WHERE "group_id" = 10;
-
--- Add a blob-average member targeting an average of 3 blobs/block. blob-average
--- is driven by target_average (not throughput), so it joins with weight 0: it
--- takes no share of the group's shared-throughput budget and simply runs at its
--- own target average alongside the other members.
+-- Add a blob-average member to the existing "Regular Chain Load" group, targeting
+-- an average of 3 blobs/block. Created paused (status 0) like the other members
+-- of that template group. blob-average is driven by target_average (not
+-- throughput), so it joins with weight 0: it takes no share of the group's
+-- shared-throughput budget and simply runs at its own target average alongside
+-- the other members.
 INSERT INTO "spammers" ("id", "scenario", "name", "description", "config", "status", "created_at", "state", "group_id", "group_config")
 VALUES
 (30, 'blob-average', 'Blob Average', 'Maintains a steady average of ~3 blobs per block.', '# wallet settings
@@ -31,7 +27,7 @@ blob_fee: 20
 client_group: ""
 log_txs: false
 
-', 1, 0, '{}', 10, '{"weight": 0, "enabled": true, "sort_order": 9}');
+', 0, 0, '{}', 10, '{"weight": 0, "enabled": true, "sort_order": 9}');
 
 -- +goose StatementEnd
 
@@ -39,6 +35,5 @@ log_txs: false
 -- +goose StatementBegin
 
 DELETE FROM "spammers" WHERE "id" = 30 AND "group_id" = 10;
-UPDATE "spammers" SET "status" = 0 WHERE "group_id" = 10;
 
 -- +goose StatementEnd

--- a/scenarios/blob-average/blobaverage.go
+++ b/scenarios/blob-average/blobaverage.go
@@ -66,7 +66,7 @@ var ScenarioDefaultOptions = ScenarioOptions{
 	TipFee:          2,
 	BlobFee:         20,
 	BlobV1Percent:   100,
-	FuluActivation:  math.MaxInt64,
+	FuluActivation:  0, // 0 = Fulu active since genesis -> send v1 (cell-proof) blobs by default
 	BlobData:        "",
 	ClientGroup:     "",
 	SubmitCount:     3,


### PR DESCRIPTION
## Summary

Adds a `blob-average` member to the existing **Regular Chain Load** group, targeting an average of ~3 blobs/block. The group is **not** enabled by default — the new member is created paused (status 0), like the other members of that template group.

## Details

- `blob-average` is driven by `target_average` (blobs/block), not `throughput`. Regular Chain Load is a shared-throughput group, so blob-average joins with **weight 0**: it takes no share of the shared throughput budget and runs at its own `target_average: 3` alongside the other members. `ResolveMemberConfig` only injects a shared-throughput value into scenarios that have a throughput field, so blob-average's own config is left intact at runtime.
- blob-average's `fulu_activation` default is changed from never to `0` (Fulu active since genesis), so it submits v1 (cell-proof) blob sidecars by default — correct for current post-Fusaka networks. Overridable via `--fulu-activation` / the daemon's global `fulu_activation` config.

## Testing

Full goose migration chain applies up + down on a temp SQLite DB:
- up: blob-average added (paused, weight 0); existing members untouched
- down: blob-average removed; the 9 original members remain