### PR TITLE
feat(uniswap-swaps): add per-trade slippage variance (--slippage-min/--slippage-max)

### DIFF
--- a/scenarios/uniswap-swaps/README.md
+++ b/scenarios/uniswap-swaps/README.md
@@ -35,6 +35,8 @@ spamoor uniswap-swaps [flags]
 - `--max-swap` - Maximum swap amount in wei (default: 1000000000000000000000)
 - `--buy-ratio` - Ratio of buy vs sell swaps (0-100, default: 50)
 - `--slippage` - Slippage tolerance in basis points (default: 50)
+- `--slippage-min` - Min per-trade slippage in basis points; 0 disables and uses the fixed `--slippage` (default: 0)
+- `--slippage-max` - Max per-trade slippage in basis points; when greater than `--slippage-min`, each trade draws a uniform-random tolerance in `[min, max]` (default: 0)
 - `--sell-threshold` - DAI balance threshold to force sell in wei (default: 100000000000000000000000)
 
 ### Wallet Management

--- a/scenarios/uniswap-swaps/swap_v2.go
+++ b/scenarios/uniswap-swaps/swap_v2.go
@@ -40,6 +40,16 @@ func (s *Scenario) buildV2SwapTx(ctx context.Context, wallet *spamoor.Wallet, fe
 	diff := new(big.Int).Sub(maxAmount, minAmount)
 	randomAmount := new(big.Int).Add(minAmount, new(big.Int).Rand(mathrand.New(mathrand.NewSource(time.Now().UnixNano())), diff))
 
+	// Per-trade slippage variance: when a [min,max] band is configured,
+	// draw a random tolerance for THIS trade so the victim population has
+	// varied slippage (some far juicier sandwich targets than others).
+	// Falls back to the fixed --slippage when slippage_max <= slippage_min.
+	slippage := s.options.Slippage
+	if s.options.SlippageMax > s.options.SlippageMin {
+		span := int64(s.options.SlippageMax-s.options.SlippageMin) + 1
+		slippage = s.options.SlippageMin + uint64(mathrand.Int63n(span))
+	}
+
 	// Get current token balance from cache
 	tokenBalance := s.uniswap.GetTokenBalance(wallet.GetAddress(), pair.DaiAddr)
 
@@ -96,7 +106,7 @@ func (s *Scenario) buildV2SwapTx(ctx context.Context, wallet *spamoor.Wallet, fe
 				useWeth = false
 			} else {
 				// Calculate minimum DAI amount to receive (with slippage)
-				minDaiAmount := new(big.Int).Mul(randomAmount, big.NewInt(10000-int64(s.options.Slippage)))
+				minDaiAmount := new(big.Int).Mul(randomAmount, big.NewInt(10000-int64(slippage)))
 				minDaiAmount = minDaiAmount.Div(minDaiAmount, big.NewInt(10000))
 
 				// Build buy transaction with WETH
@@ -142,7 +152,7 @@ func (s *Scenario) buildV2SwapTx(ctx context.Context, wallet *spamoor.Wallet, fe
 			}
 
 			// Calculate minimum DAI amount to receive (with slippage)
-			minDaiAmount := new(big.Int).Mul(randomAmount, big.NewInt(10000-int64(s.options.Slippage)))
+			minDaiAmount := new(big.Int).Mul(randomAmount, big.NewInt(10000-int64(slippage)))
 			minDaiAmount = minDaiAmount.Div(minDaiAmount, big.NewInt(10000))
 
 			// Build buy transaction
@@ -183,7 +193,7 @@ func (s *Scenario) buildV2SwapTx(ctx context.Context, wallet *spamoor.Wallet, fe
 			if err != nil {
 				return nil, err
 			}
-			minWethAmount := new(big.Int).Mul(amounts[1], big.NewInt(10000-int64(s.options.Slippage)))
+			minWethAmount := new(big.Int).Mul(amounts[1], big.NewInt(10000-int64(slippage)))
 			minWethAmount = minWethAmount.Div(minWethAmount, big.NewInt(10000))
 
 			// Build sell transaction for WETH
@@ -220,7 +230,7 @@ func (s *Scenario) buildV2SwapTx(ctx context.Context, wallet *spamoor.Wallet, fe
 			if err != nil {
 				return nil, err
 			}
-			minEthAmount := new(big.Int).Mul(amounts[1], big.NewInt(10000-int64(s.options.Slippage)))
+			minEthAmount := new(big.Int).Mul(amounts[1], big.NewInt(10000-int64(slippage)))
 			minEthAmount = minEthAmount.Div(minEthAmount, big.NewInt(10000))
 
 			// Build sell transaction

--- a/scenarios/uniswap-swaps/uniswap_swaps.go
+++ b/scenarios/uniswap-swaps/uniswap_swaps.go
@@ -32,6 +32,8 @@ type ScenarioOptions struct {
 	MaxSwapAmount     string  `yaml:"max_swap_amount"`
 	BuyRatio          uint64  `yaml:"buy_ratio"`
 	Slippage          uint64  `yaml:"slippage"`
+	SlippageMin       uint64  `yaml:"slippage_min"`
+	SlippageMax       uint64  `yaml:"slippage_max"`
 	SellThreshold     string  `yaml:"sell_threshold"`
 	Timeout           string  `yaml:"timeout"`
 	ClientGroup       string  `yaml:"client_group"`
@@ -72,6 +74,8 @@ var ScenarioDefaultOptions = ScenarioOptions{
 	MaxSwapAmount:     "1000000000000000000000", // 1000 DAI
 	BuyRatio:          40,
 	Slippage:          50,
+	SlippageMin:       0,
+	SlippageMax:       0,
 	SellThreshold:     "50000000000000000000000", // 50000 DAI
 	Timeout:           "",
 	ClientGroup:       "",
@@ -109,6 +113,8 @@ func (s *Scenario) Flags(flags *pflag.FlagSet) error {
 	flags.StringVar(&s.options.MaxSwapAmount, "max-swap", ScenarioDefaultOptions.MaxSwapAmount, "Maximum swap amount in wei")
 	flags.Uint64Var(&s.options.BuyRatio, "buy-ratio", ScenarioDefaultOptions.BuyRatio, "Ratio of buy vs sell swaps (0-100)")
 	flags.Uint64Var(&s.options.Slippage, "slippage", ScenarioDefaultOptions.Slippage, "Slippage tolerance in basis points")
+	flags.Uint64Var(&s.options.SlippageMin, "slippage-min", ScenarioDefaultOptions.SlippageMin, "Min per-trade slippage in bps (0 disables; use fixed --slippage)")
+	flags.Uint64Var(&s.options.SlippageMax, "slippage-max", ScenarioDefaultOptions.SlippageMax, "Max per-trade slippage in bps (when > slippage-min, slippage is randomized per trade)")
 	flags.StringVar(&s.options.SellThreshold, "sell-threshold", ScenarioDefaultOptions.SellThreshold, "DAI balance threshold to force sell (in wei)")
 	flags.StringVar(&s.options.Timeout, "timeout", ScenarioDefaultOptions.Timeout, "Timeout for the scenario (e.g. '1h', '30m', '5s') - empty means no timeout")
 	flags.StringVar(&s.options.ClientGroup, "client-group", ScenarioDefaultOptions.ClientGroup, "Client group to use for sending transactions")


### PR DESCRIPTION
## What

Adds two options to the `uniswap-swaps` scenario:

- `--slippage-min` (bps) / `slippage_min`
- `--slippage-max` (bps) / `slippage_max`

When `slippage-max > slippage-min`, each V2 swap draws a **uniform-random slippage tolerance in `[min, max]`** rather than applying the single fixed `--slippage` to every trade. When the band is unset (`slippage-max <= slippage-min`) behaviour is unchanged and the fixed `--slippage` is used.

## Why

Today `--slippage` applies one identical tolerance to every trade, so the only thing that differs between generated swaps is size. For MEV / sandwich-attack research — and for exercising swap execution under varied `amountOutMin` floors — it's useful to generate a population of victims whose *tolerance itself* varies. A random band makes some swaps far more attractive targets than others, which is closer to real mempool traffic.

## Notes

- **V2 only:** the V3 path leaves `amountOutMinimum = 0` upstream, so slippage (fixed or banded) only affects V2 swaps — consistent with how the existing `--slippage` behaves.
- **No behaviour change by default:** `slippage-min` and `slippage-max` both default to `0`.
- `gofmt -s`, `go vet ./scenarios/uniswap-swaps/`, and `go build ./scenarios/uniswap-swaps/` pass.
- README options list updated.

## Example

```bash
# victims span 0.5% .. 10% slippage tolerance
spamoor uniswap-swaps -p "<PRIVKEY>" -h http://rpc-host:8545 -t 10 \
  --slippage-min 50 --slippage-max 1000
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)