### PR TITLE
fix(storagerefundtx): update gas constants for Amsterdam EIP-8038

### DIFF
--- a/scenarios/storagerefundtx/storagerefundtx.go
+++ b/scenarios/storagerefundtx/storagerefundtx.go
@@ -354,17 +354,18 @@ func (s *Scenario) sendDeploymentTx(
 }
 
 // gasLimitForSlots estimates the gas limit needed for a given number of
-// storage slots to write and clear. Accounts for EIP-2929 cold storage
-// access surcharges on top of base SSTORE costs:
-//   - Write (zero to non-zero, cold): 20,000 + 2,100 = 22,100 gas
-//   - Clear (non-zero to zero, cold): 2,900 + 2,100 = 5,000 gas
+// storage slots to write and clear. Under Amsterdam (EIP-8038), cold storage
+// write costs are restructured — COLD_STORAGE_WRITE=5000 replaces the old
+// SSTORE_SET(20000)+COLD_SLOAD(2100) combination:
+//   - Write (zero to non-zero, cold): 5,000 gas (COLD_STORAGE_WRITE)
+//   - Clear (non-zero to zero, warm): 100 gas (WARM_ACCESS)
 //   - Mapping keccak256 + loop overhead: ~200 gas per slot
 //
 // Plus fixed overhead for function call, state variable reads/writes.
 func gasLimitForSlots(slotsPerCall, costPerStateByte uint64) uint64 {
 	// Steady-state per-slot execution cost: write + clear + loop overhead.
-	writeGas := uint64(22300)   // SSTORE_SET(20k) + COLD_SLOAD(2.1k) + margin
-	clearGas := uint64(5200)    // SSTORE_RESET(2.9k) + COLD_SLOAD(2.1k) + margin
+	writeGas := uint64(5300)    // COLD_STORAGE_WRITE(5k) + margin
+	clearGas := uint64(200)     // WARM_ACCESS(100) + margin
 	loopOverhead := uint64(200) // keccak256, stack ops, jump per iteration
 	overhead := uint64(300000)  // function dispatch, state var access, margin
 


### PR DESCRIPTION
## Summary

- Updates `gasLimitForSlots` in `storagerefundtx.go` with correct Amsterdam gas costs
- `COLD_STORAGE_WRITE` (5k) replaces `SSTORE_SET(20k) + COLD_SLOAD(2.1k)` for writes
- Warm clears drop from 5.2k to 100 gas (WARM_ACCESS only)
- Old constants caused the gas estimate to be ~4× too high, leading to OOG on contract deployment when the overestimate pushed the tx above `MaxTxGas` and the 2D gas split allocated zero state gas

## Test plan

- [ ] Launch a glamsterdam-devnet-6 enclave with the storagerefundtx spammer enabled
- [ ] Confirm the deployment tx is accepted and the spammer reaches steady-state slot/clear cycles