### PR TITLE
fix(txpool): fetch header not full block in tryInitBlockStats

### DIFF
--- a/spamoor/txpool.go
+++ b/spamoor/txpool.go
@@ -1734,13 +1734,15 @@ func (pool *TxPool) tryInitBlockStats(ctx context.Context) error {
 	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	latestBlock, err := client.client.BlockByNumber(fetchCtx, nil)
+	// Header-only: a full block decode fails on chains with custom tx types
+	// go-ethereum can't decode, and we only need the gas limit and base fee.
+	latestHeader, err := client.client.HeaderByNumber(fetchCtx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to fetch latest block for gas limit: %w", err)
+		return fmt.Errorf("failed to fetch latest header for gas limit: %w", err)
 	}
 
-	pool.currentGasLimit = latestBlock.GasLimit()
-	pool.currentBaseFee = latestBlock.BaseFee()
+	pool.currentGasLimit = latestHeader.GasLimit
+	pool.currentBaseFee = latestHeader.BaseFee
 	logrus.Infof("initialized block stats from latest block: gasLimit=%v baseFee=%v amsterdamFeeModel=%v",
 		pool.currentGasLimit, pool.currentBaseFee, !pool.preAmsterdamFeeModel)
 


### PR DESCRIPTION
## Problem

`spamoor` panics on startup against any chain that includes a transaction type go-ethereum cannot decode:

```
panic: failed to initialize block stats: ... transaction type not supported
```

`TxPool.tryInitBlockStats` fetches the **full** latest block via `client.BlockByNumber(ctx, nil)` purely to read the gas limit and base fee. `BlockByNumber` decodes every transaction in the block, so if the latest block contains a custom/unknown tx type, init fails before a single transaction is sent. On chains that emit such a tx in every block, spamoor cannot start at all.

(Concretely: an OP-stack-style L2 with a per-block system transaction of a custom type — but this affects any chain with non-standard tx types.)

## Fix

Fetch the header instead of the full block. `tryInitBlockStats` only reads `GasLimit` and `BaseFee`, both present on the header, and `HeaderByNumber` never decodes transactions.

This is consistent with the existing block-processing path: `getBlockBody` already decodes blocks manually and **skips** unknown transaction types (`txSkipMap`). The init path was the only remaining place that required a full block decode, so it was the only place that still crashed.

## Testing

Built and vetted. Verified against a live chain that emits a custom tx type in every block: stock spamoor panics on startup, the patched build initializes block stats, deploys, and runs `storagespam` to ~96% block-gas saturation with all txs confirmed.
