### PR TITLE
Deep copy metrics data points before returning them to readers

### DIFF
--- a/daemon/metrics_collector.go
+++ b/daemon/metrics_collector.go
@@ -201,9 +201,11 @@ func (mc *TxPoolMetricsCollector) processBlockForWindow(
 	mc.logger.Tracef("Processed block %d for window (granularity %d): total_gas=%d, spammer_gas=%d, others_gas=%d",
 		blockNumber, window.blockGranularity, totalGasUsed, totalSpammerGas, othersGasUsed)
 
-	// Return the data point only for short window (granularity 1)
+	// Return the data point only for short window (granularity 1). Hand back a
+	// copy so subscribers do not read the live map the collector keeps mutating.
 	if window.blockGranularity == 1 {
-		return updatedDataPoint
+		dataPointCopy := updatedDataPoint.copy()
+		return &dataPointCopy
 	}
 	return nil
 }
@@ -343,13 +345,37 @@ func (mc *TxPoolMetricsCollector) GetLongWindowMetrics() *MultiGranularityMetric
 	return mc.longWindow
 }
 
-// GetDataPoints returns a copy of data points for a specific window
+// copy returns a deep copy of the data point. The SpammerGasData map is copied
+// so callers can keep reading the result after releasing the window lock without
+// racing the collector, which keeps mutating the live map as new blocks are
+// aggregated into the current data point.
+func (p *BlockDataPoint) copy() BlockDataPoint {
+	result := *p
+	if p.SpammerGasData != nil {
+		result.SpammerGasData = make(map[uint64]*SpammerBlockData, len(p.SpammerGasData))
+		for id, data := range p.SpammerGasData {
+			if data == nil {
+				result.SpammerGasData[id] = nil
+				continue
+			}
+			dataCopy := *data
+			result.SpammerGasData[id] = &dataCopy
+		}
+	}
+	return result
+}
+
+// GetDataPoints returns a deep copy of data points for a specific window.
+// The nested maps are copied so the returned data is safe to read without
+// holding the window lock.
 func (mgm *MultiGranularityMetrics) GetDataPoints() []BlockDataPoint {
 	mgm.mutex.RLock()
 	defer mgm.mutex.RUnlock()
 
 	result := make([]BlockDataPoint, len(mgm.dataPoints))
-	copy(result, mgm.dataPoints)
+	for i := range mgm.dataPoints {
+		result[i] = mgm.dataPoints[i].copy()
+	}
 	return result
 }
 

--- a/daemon/metrics_collector_test.go
+++ b/daemon/metrics_collector_test.go
@@ -1,0 +1,97 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// newAggregatingMetrics returns a window with a very large granularity so every
+// block aggregates into a single data point. That keeps the collector mutating
+// one shared SpammerGasData map, which is the case the copy is meant to protect.
+func newAggregatingMetrics() *MultiGranularityMetrics {
+	m := &MultiGranularityMetrics{
+		blockGranularity: 1_000_000,
+		windowDuration:   time.Hour,
+		maxDataPoints:    1 << 20,
+		currentSpammers:  make(map[uint64]*SpammerSnapshot),
+	}
+	m.mutex.Lock()
+	m.addDataPoint(1, time.Now(), 1, map[uint64]*SpammerBlockData{0: {}}, 0)
+	m.mutex.Unlock()
+	return m
+}
+
+// GetDataPoints must return data that is independent from the live collector.
+// A later mutation of the collector must not be visible through an earlier result.
+func TestGetDataPointsReturnsIndependentCopy(t *testing.T) {
+	m := newAggregatingMetrics()
+
+	points := m.GetDataPoints()
+	if len(points) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(points))
+	}
+	if _, ok := points[0].SpammerGasData[7]; ok {
+		t.Fatal("spammer 7 should not be present yet")
+	}
+
+	// Add a new spammer to the live data point after the copy was taken.
+	m.mutex.Lock()
+	m.addDataPoint(2, time.Now(), 10, map[uint64]*SpammerBlockData{7: {GasUsed: 10}}, 0)
+	m.mutex.Unlock()
+
+	if _, ok := points[0].SpammerGasData[7]; ok {
+		t.Fatal("earlier result changed after the collector was mutated; the map is still shared")
+	}
+}
+
+// TestGetDataPointsConcurrentReaders exercises the reader pattern used by the
+// dashboard and SSE handlers (GetDataPoints followed by ranging SpammerGasData)
+// while the collector aggregates new blocks. Run with -race to confirm the
+// returned maps are not shared with the collector.
+func TestGetDataPointsConcurrentReaders(t *testing.T) {
+	m := newAggregatingMetrics()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := uint64(2)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			m.mutex.Lock()
+			m.addDataPoint(i, time.Now(), 1, map[uint64]*SpammerBlockData{i: {GasUsed: i}}, 0)
+			m.mutex.Unlock()
+			i++
+		}
+	}()
+
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				for _, p := range m.GetDataPoints() {
+					for id, data := range p.SpammerGasData {
+						_, _ = id, data
+					}
+				}
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem

GetDataPoints and the realtime subscriber update returned metrics data points whose SpammerGasData maps were shared with the live collector. The dashboard and SSE handlers iterate those maps without holding the window lock while the collector keeps aggregating new blocks into the same maps. That concurrent map access is a fatal Go runtime error and takes down the whole daemon.

## Fix

Deep copy the nested maps when returning data points from GetDataPoints and when building the realtime subscriber update, so every reader gets its own copy. The collector keeps mutating the live maps under the window lock. This matches the pattern GetSpammerSnapshots already uses.

## Testing

- go build, go vet, staticcheck and gofmt are clean
- Added a test that confirms GetDataPoints results stay independent from later collector mutations
- Added a concurrent readers test that passes under the race detector, where the shared map previously raced