### PR TITLE
Release transaction state once it has been logged in order

### DIFF
--- a/scenario/txscenario.go
+++ b/scenario/txscenario.go
@@ -103,10 +103,11 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 				state.logCb = nil
 			}
 
-			// Clean up if the transaction is done
-			if state.done {
-				delete(txStates, nextLogIdx)
-			}
+			// The transaction has been logged in order, so its state is no longer
+			// needed here. The worker goroutine keeps its own reference for the
+			// rest of its teardown, so removing it from the map does not affect
+			// in-flight work and keeps the map from growing with every transaction.
+			delete(txStates, nextLogIdx)
 
 			nextLogIdx++
 		}

--- a/scenario/txscenario_test.go
+++ b/scenario/txscenario_test.go
@@ -1,0 +1,110 @@
+package scenario
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func discardLogger() *logrus.Entry {
+	lg := logrus.New()
+	lg.SetOutput(io.Discard)
+	return lg.WithField("test", "txscenario")
+}
+
+// TestTransactionStateReleased runs a large number of transactions through the
+// scenario and checks that per-transaction bookkeeping does not accumulate. A
+// leak would show up as live heap objects growing roughly in step with the
+// number of processed transactions.
+func TestTransactionStateReleased(t *testing.T) {
+	const total = 20000
+
+	var baseline, peak uint64
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := RunTransactionScenario(ctx, TransactionScenarioOptions{
+		TotalCount: total,
+		Throughput: 60000, // paced so only a few transactions are in flight at a time
+		MaxPending: 0,
+		Logger:     discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			params.NotifySubmitted()
+			switch params.TxIdx {
+			case 2000:
+				runtime.GC()
+				var m runtime.MemStats
+				runtime.ReadMemStats(&m)
+				baseline = m.HeapObjects
+			case total - 1:
+				runtime.GC()
+				var m runtime.MemStats
+				runtime.ReadMemStats(&m)
+				peak = m.HeapObjects
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+	if baseline == 0 || peak == 0 {
+		t.Fatalf("measurements not captured (baseline=%d peak=%d)", baseline, peak)
+	}
+
+	growth := int64(peak) - int64(baseline)
+	if growth > total/4 {
+		t.Fatalf("live heap objects grew by %d over %d transactions; per-transaction state is not being released", growth, total-2000)
+	}
+	t.Logf("live heap objects grew by %d over %d transactions (bounded)", growth, total-2000)
+}
+
+// TestOrderedLoggingInOrder verifies that ordered log callbacks still fire
+// exactly once, in submission order, so the cleanup change does not affect
+// ordered logging.
+func TestOrderedLoggingInOrder(t *testing.T) {
+	const total = 1000
+
+	var mu sync.Mutex
+	order := make([]uint64, 0, total)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := RunTransactionScenario(ctx, TransactionScenarioOptions{
+		TotalCount: total,
+		Throughput: 60000,
+		MaxPending: 0,
+		Logger:     discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			idx := params.TxIdx
+			params.OrderedLogCb(func() {
+				mu.Lock()
+				order = append(order, idx)
+				mu.Unlock()
+			})
+			params.NotifySubmitted()
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != total {
+		t.Fatalf("expected %d ordered log callbacks, got %d", total, len(order))
+	}
+	for i, v := range order {
+		if v != uint64(i) {
+			t.Fatalf("ordered log out of order at position %d: got %d", i, v)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

RunTransactionScenario tracks per-transaction bookkeeping in a map (txStates) and delivers ordered log callbacks. An entry was only removed when the log processor reached it while the transaction was already done. A transaction that gets logged while still in flight is advanced past and never revisited, so its entry is never deleted. Over a long run the map grows with every transaction and leaks memory.

## Fix

Delete the entry as soon as its ordered logs have run, rather than only when it happens to be done at that moment. The worker goroutine keeps its own reference to the state for the rest of its teardown, so removing it from the map does not affect in-flight work, and ordered logging is unchanged.

## Testing

- A new test runs 20000 transactions and checks that live heap objects stay bounded. Before the change it grows by about one object per transaction; after the change it is flat.
- A second test confirms ordered log callbacks still fire exactly once, in submission order.
- go build, go vet, staticcheck, gofmt and the race detector are clean.