### PR TITLE
Release transaction state once logged & fix data races in RunTransactionScenario

### DIFF
--- a/scenario/config_validator_test.go
+++ b/scenario/config_validator_test.go
@@ -1,0 +1,170 @@
+package scenario
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// validatorTestOptions mimics a typical scenario options struct with yaml tags.
+type validatorTestOptions struct {
+	Throughput uint64 `yaml:"throughput" usage:"transactions per slot"`
+	MaxPending uint64 `yaml:"max_pending,omitempty" usage:"max pending transactions"`
+	DashField  string `yaml:"dash-field"`
+	Hidden     string `yaml:"-"`
+	NoTag      string
+	Fallback   string `yaml:",omitempty"`
+}
+
+func testDescriptor() *Descriptor {
+	return &Descriptor{
+		Name:           "testscenario",
+		Description:    "scenario for validator tests",
+		DefaultOptions: &validatorTestOptions{Throughput: 10},
+	}
+}
+
+func TestGetScenarioValidFields(t *testing.T) {
+	fields := GetScenarioValidFields(testDescriptor())
+
+	throughput, ok := fields["throughput"]
+	if !ok {
+		t.Fatal("expected 'throughput' field to be extracted")
+	}
+	if throughput.Type != reflect.TypeOf(uint64(0)) {
+		t.Fatalf("expected uint64 type for 'throughput', got %v", throughput.Type)
+	}
+	if throughput.DefaultValue != uint64(10) {
+		t.Fatalf("expected default value 10 for 'throughput', got %v", throughput.DefaultValue)
+	}
+	if throughput.Description != "transactions per slot" {
+		t.Fatalf("unexpected description: %q", throughput.Description)
+	}
+
+	// yaml tag options like ",omitempty" are stripped from the field name
+	if _, ok := fields["max_pending"]; !ok {
+		t.Fatal("expected 'max_pending' field to be extracted")
+	}
+
+	// a yaml tag without a name falls back to the lowercased Go field name
+	if _, ok := fields["fallback"]; !ok {
+		t.Fatal("expected 'fallback' field to be extracted")
+	}
+
+	// fields without a yaml tag or explicitly excluded are not extracted
+	if _, ok := fields["hidden"]; ok {
+		t.Fatal("expected 'hidden' (yaml:\"-\") field to be excluded")
+	}
+	if _, ok := fields["notag"]; ok {
+		t.Fatal("expected untagged field to be excluded")
+	}
+
+	// wallet pool configuration fields are always valid
+	for _, walletField := range []string{"wallet_count", "seed", "refill_amount"} {
+		if _, ok := fields[walletField]; !ok {
+			t.Fatalf("expected wallet pool field %q to be extracted", walletField)
+		}
+	}
+}
+
+func TestGetScenarioValidFieldsNonStructOptions(t *testing.T) {
+	fields := GetScenarioValidFields(&Descriptor{
+		Name:           "badoptions",
+		DefaultOptions: "not a struct",
+	})
+
+	// only the wallet pool fields remain
+	if _, ok := fields["wallet_count"]; !ok {
+		t.Fatal("expected wallet pool fields to be extracted")
+	}
+	if _, ok := fields["throughput"]; ok {
+		t.Fatal("did not expect scenario fields from a non-struct options value")
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	fields := GetScenarioValidFields(testDescriptor())
+	validator := NewConfigValidator("testscenario", fields, discardLogger())
+
+	tests := []struct {
+		name        string
+		config      string
+		valid       bool
+		errContains string
+	}{
+		{name: "empty config", config: "", valid: true},
+		{name: "known fields", config: "throughput: 10\nmax_pending: 5", valid: true},
+		{name: "invalid yaml", config: "throughput: [unclosed", valid: false, errContains: "Invalid YAML"},
+		{name: "unknown field", config: "totally_unknown_xyz: 1", valid: false, errContains: "invalid configuration fields"},
+		{name: "dash instead of underscore", config: "max-pending: 5", valid: false, errContains: "'max-pending' -> 'max_pending'"},
+		{name: "underscore instead of dash", config: "dash_field: x", valid: false, errContains: "'dash_field' -> 'dash-field'"},
+		{name: "wrong case", config: "THROUGHPUT: 5", valid: false, errContains: "'THROUGHPUT' -> 'throughput'"},
+		{name: "partial field name", config: "pending: 5", valid: false, errContains: "-> 'max_pending'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validator.ValidateConfig(tt.config)
+			if result.Valid != tt.valid {
+				t.Fatalf("expected valid=%v, got %v (errors: %v)", tt.valid, result.Valid, result.Errors)
+			}
+			if tt.valid {
+				if len(result.Errors) != 0 {
+					t.Fatalf("expected no errors, got %v", result.Errors)
+				}
+				return
+			}
+			if len(result.Errors) == 0 {
+				t.Fatal("expected validation errors")
+			}
+			if tt.errContains != "" && !strings.Contains(result.Errors[0], tt.errContains) {
+				t.Fatalf("expected error to contain %q, got %q", tt.errContains, result.Errors[0])
+			}
+		})
+	}
+}
+
+func TestValidateScenarioConfig(t *testing.T) {
+	if err := ValidateScenarioConfig(nil, "", discardLogger()); err == nil {
+		t.Fatal("expected error for nil descriptor")
+	}
+
+	if err := ValidateScenarioConfig(testDescriptor(), "throughput: 20", discardLogger()); err != nil {
+		t.Fatalf("expected valid config to pass, got %v", err)
+	}
+
+	if err := ValidateScenarioConfig(testDescriptor(), "totally_unknown_xyz: 1", discardLogger()); err == nil {
+		t.Fatal("expected error for unknown config field")
+	}
+}
+
+func TestParseAndValidateConfig(t *testing.T) {
+	target := &validatorTestOptions{}
+	err := ParseAndValidateConfig(testDescriptor(), "throughput: 42\nmax_pending: 7", target, discardLogger())
+	if err != nil {
+		t.Fatalf("expected config to parse, got %v", err)
+	}
+	if target.Throughput != 42 || target.MaxPending != 7 {
+		t.Fatalf("expected parsed values 42/7, got %d/%d", target.Throughput, target.MaxPending)
+	}
+
+	// an empty config leaves the target untouched
+	target = &validatorTestOptions{Throughput: 5}
+	if err := ParseAndValidateConfig(testDescriptor(), "", target, discardLogger()); err != nil {
+		t.Fatalf("expected empty config to be valid, got %v", err)
+	}
+	if target.Throughput != 5 {
+		t.Fatalf("expected target to be unchanged, got %d", target.Throughput)
+	}
+
+	// unknown fields are rejected before parsing
+	if err := ParseAndValidateConfig(testDescriptor(), "totally_unknown_xyz: 1", target, discardLogger()); err == nil {
+		t.Fatal("expected error for unknown config field")
+	}
+
+	// type mismatches surface as unmarshal errors
+	err = ParseAndValidateConfig(testDescriptor(), "throughput: notanumber", target, discardLogger())
+	if err == nil || !strings.Contains(err.Error(), "failed to unmarshal config") {
+		t.Fatalf("expected unmarshal error, got %v", err)
+	}
+}

--- a/scenario/receiptchan_test.go
+++ b/scenario/receiptchan_test.go
@@ -1,0 +1,50 @@
+package scenario
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func TestReceiptChanWaitNilChannel(t *testing.T) {
+	var rc ReceiptChan
+
+	receipt, err := rc.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error for nil channel, got %v", err)
+	}
+	if receipt != nil {
+		t.Fatalf("expected nil receipt for nil channel, got %v", receipt)
+	}
+}
+
+func TestReceiptChanWaitReceivesReceipt(t *testing.T) {
+	rc := make(ReceiptChan, 1)
+	want := &types.Receipt{Status: types.ReceiptStatusSuccessful}
+	rc <- want
+
+	got, err := rc.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected the sent receipt to be returned, got %v", got)
+	}
+}
+
+func TestReceiptChanWaitContextCancelled(t *testing.T) {
+	rc := make(ReceiptChan)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	receipt, err := rc.Wait(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if receipt != nil {
+		t.Fatalf("expected nil receipt on cancellation, got %v", receipt)
+	}
+}

--- a/scenario/registry_test.go
+++ b/scenario/registry_test.go
@@ -1,0 +1,188 @@
+package scenario
+
+import (
+	"slices"
+	"testing"
+)
+
+type stubPlugin struct {
+	name string
+}
+
+func (p *stubPlugin) GetName() string        { return p.name }
+func (p *stubPlugin) GetDescription() string { return "stub plugin" }
+func (p *stubPlugin) AddRunning()            {}
+func (p *stubPlugin) RemoveRunning()         {}
+
+func newTestRegistry() *Registry {
+	return NewRegistry([]*Descriptor{
+		{Name: "eoatx", Aliases: []string{"transfer-tx"}, Description: "native eoa scenario"},
+		{Name: "erctx", Description: "native erc scenario"},
+	})
+}
+
+func pluginEntry(name string, aliases ...string) *ScenarioEntry {
+	return &ScenarioEntry{
+		Descriptor: &Descriptor{Name: name, Aliases: aliases, Description: "plugin scenario"},
+		Source:     ScenarioSourcePlugin,
+		Plugin:     &stubPlugin{name: "test-plugin"},
+	}
+}
+
+func TestRegistryGet(t *testing.T) {
+	r := newTestRegistry()
+
+	if entry := r.Get("eoatx"); entry == nil || entry.Descriptor.Name != "eoatx" {
+		t.Fatalf("expected to find scenario by name, got %v", entry)
+	}
+
+	if entry := r.Get("transfer-tx"); entry == nil || entry.Descriptor.Name != "eoatx" {
+		t.Fatalf("expected to find scenario by alias, got %v", entry)
+	}
+
+	if entry := r.Get("unknown"); entry != nil {
+		t.Fatalf("expected nil for unknown scenario, got %v", entry)
+	}
+}
+
+func TestRegistryRegister(t *testing.T) {
+	r := newTestRegistry()
+
+	// New plugin scenario registers without replacing anything
+	old, err := r.Register(pluginEntry("plugin-scenario"))
+	if err != nil {
+		t.Fatalf("unexpected error registering plugin scenario: %v", err)
+	}
+	if old != nil {
+		t.Fatalf("expected no replaced entry, got %v", old)
+	}
+
+	// Re-registering the same name replaces the entry and returns the old one
+	replacement := pluginEntry("plugin-scenario")
+	old, err = r.Register(replacement)
+	if err != nil {
+		t.Fatalf("unexpected error replacing plugin scenario: %v", err)
+	}
+	if old == nil || old.Descriptor.Name != "plugin-scenario" {
+		t.Fatalf("expected replaced entry to be returned, got %v", old)
+	}
+	if got := r.Get("plugin-scenario"); got != replacement {
+		t.Fatalf("expected registry to hold the replacement entry")
+	}
+
+	// Native scenarios cannot be overridden by name
+	if _, err := r.Register(pluginEntry("eoatx")); err == nil {
+		t.Fatal("expected error when overriding a native scenario")
+	}
+
+	// Native scenario aliases cannot be shadowed either
+	if _, err := r.Register(pluginEntry("other-name", "transfer-tx")); err == nil {
+		t.Fatal("expected error when a plugin alias collides with a native alias")
+	}
+}
+
+func TestRegistryGetDescriptor(t *testing.T) {
+	r := newTestRegistry()
+
+	if desc := r.GetDescriptor("erctx"); desc == nil || desc.Name != "erctx" {
+		t.Fatalf("expected descriptor for registered scenario, got %v", desc)
+	}
+
+	if desc := r.GetDescriptor("unknown"); desc != nil {
+		t.Fatalf("expected nil descriptor for unknown scenario, got %v", desc)
+	}
+}
+
+func TestRegistryGetAllAndNames(t *testing.T) {
+	r := newTestRegistry()
+
+	if _, err := r.Register(pluginEntry("plugin-scenario")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	descriptors := r.GetAll()
+	if len(descriptors) != 3 {
+		t.Fatalf("expected 3 descriptors, got %d", len(descriptors))
+	}
+
+	names := r.GetNames()
+	if len(names) != 3 {
+		t.Fatalf("expected 3 names, got %d", len(names))
+	}
+	for _, expected := range []string{"eoatx", "erctx", "plugin-scenario"} {
+		if !slices.Contains(names, expected) {
+			t.Fatalf("expected names to contain %q, got %v", expected, names)
+		}
+	}
+}
+
+func TestRegistryIsNative(t *testing.T) {
+	r := newTestRegistry()
+
+	if _, err := r.Register(pluginEntry("plugin-scenario")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.IsNative("eoatx") {
+		t.Fatal("expected native scenario name to be native")
+	}
+	if !r.IsNative("transfer-tx") {
+		t.Fatal("expected native scenario alias to be native")
+	}
+	if r.IsNative("plugin-scenario") {
+		t.Fatal("expected plugin scenario to not be native")
+	}
+	if r.IsNative("unknown") {
+		t.Fatal("expected unknown scenario to not be native")
+	}
+}
+
+func TestRegistryRemove(t *testing.T) {
+	r := newTestRegistry()
+
+	if _, err := r.Remove("eoatx"); err == nil {
+		t.Fatal("expected error when removing a native scenario")
+	}
+
+	entry := pluginEntry("plugin-scenario")
+	if _, err := r.Register(entry); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	old, err := r.Remove("plugin-scenario")
+	if err != nil {
+		t.Fatalf("unexpected error removing plugin scenario: %v", err)
+	}
+	if old != entry {
+		t.Fatalf("expected removed entry to be returned, got %v", old)
+	}
+	if got := r.Get("plugin-scenario"); got != nil {
+		t.Fatalf("expected scenario to be gone after removal, got %v", got)
+	}
+
+	// Removing an unknown scenario is a no-op
+	old, err = r.Remove("unknown")
+	if err != nil {
+		t.Fatalf("unexpected error removing unknown scenario: %v", err)
+	}
+	if old != nil {
+		t.Fatalf("expected nil entry for unknown scenario, got %v", old)
+	}
+}
+
+func TestRegistryGetPluginScenarios(t *testing.T) {
+	r := newTestRegistry()
+
+	if entries := r.GetPluginScenarios(); len(entries) != 0 {
+		t.Fatalf("expected no plugin scenarios initially, got %d", len(entries))
+	}
+
+	if _, err := r.Register(pluginEntry("plugin-scenario")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries := r.GetPluginScenarios()
+	if len(entries) != 1 || entries[0].Descriptor.Name != "plugin-scenario" {
+		t.Fatalf("expected exactly the plugin scenario, got %v", entries)
+	}
+}

--- a/scenario/throughput_tracker_test.go
+++ b/scenario/throughput_tracker_test.go
@@ -1,0 +1,76 @@
+package scenario
+
+import (
+	"testing"
+)
+
+func TestThroughputTrackerAverage(t *testing.T) {
+	tracker := newThroughputTracker()
+
+	// no data recorded yet
+	if got := tracker.getAverageThroughput(5, 10); got != 0 {
+		t.Fatalf("expected 0 for empty tracker, got %f", got)
+	}
+
+	for block := uint64(1); block <= 5; block++ {
+		tracker.recordCompletion(block, 10)
+	}
+
+	if got := tracker.getAverageThroughput(5, 5); got != 10 {
+		t.Fatalf("expected average of 10 over 5 blocks, got %f", got)
+	}
+
+	if got := tracker.getAverageThroughput(3, 5); got != 10 {
+		t.Fatalf("expected average of 10 over 3 blocks, got %f", got)
+	}
+
+	// requesting more blocks than tracked falls back to the tracked range
+	if got := tracker.getAverageThroughput(50, 5); got != 10 {
+		t.Fatalf("expected average of 10 when requesting more blocks than tracked, got %f", got)
+	}
+
+	// zero parameters yield no average
+	if got := tracker.getAverageThroughput(0, 5); got != 0 {
+		t.Fatalf("expected 0 for zero block count, got %f", got)
+	}
+	if got := tracker.getAverageThroughput(5, 0); got != 0 {
+		t.Fatalf("expected 0 for zero current block, got %f", got)
+	}
+
+	// a window far past the recorded blocks contains no data
+	if got := tracker.getAverageThroughput(3, 1000); got != 0 {
+		t.Fatalf("expected 0 for a window without recorded blocks, got %f", got)
+	}
+}
+
+func TestThroughputTrackerUpdatesExistingBlock(t *testing.T) {
+	tracker := newThroughputTracker()
+
+	tracker.recordCompletion(1, 4)
+	tracker.recordCompletion(2, 4)
+	// recording the same block again adds to the existing entry
+	tracker.recordCompletion(1, 6)
+
+	if got := tracker.getAverageThroughput(2, 2); got != 7 {
+		t.Fatalf("expected average of 7 ((4+6)+4)/2, got %f", got)
+	}
+}
+
+func TestThroughputTrackerRingWraparound(t *testing.T) {
+	tracker := newThroughputTracker()
+
+	// record more blocks than the ring buffer holds
+	for block := uint64(1); block <= 150; block++ {
+		tracker.recordCompletion(block, block)
+	}
+
+	// the most recent blocks are still tracked: blocks 141..150 sum to 1455
+	if got := tracker.getAverageThroughput(10, 150); got != 145.5 {
+		t.Fatalf("expected average of 145.5 over the last 10 blocks, got %f", got)
+	}
+
+	// blocks that have been evicted from the ring no longer contribute
+	if got := tracker.getAverageThroughput(10, 50); got != 0 {
+		t.Fatalf("expected 0 for evicted blocks, got %f", got)
+	}
+}

--- a/scenario/txscenario.go
+++ b/scenario/txscenario.go
@@ -103,10 +103,11 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 				state.logCb = nil
 			}
 
-			// Clean up if the transaction is done
-			if state.done {
-				delete(txStates, nextLogIdx)
-			}
+			// The transaction has been logged in order, so its state is no longer
+			// needed here. The worker goroutine keeps its own reference for the
+			// rest of its teardown, so removing it from the map does not affect
+			// in-flight work and keeps the map from growing with every transaction.
+			delete(txStates, nextLogIdx)
 
 			nextLogIdx++
 		}

--- a/scenario/txscenario.go
+++ b/scenario/txscenario.go
@@ -84,11 +84,9 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 	txStatesMutex := sync.Mutex{}
 	nextLogIdx := uint64(0)
 
-	// Helper function to process pending logs in order
+	// Helper function to process pending logs in order.
+	// The caller must hold txStatesMutex.
 	processPendingLogs := func() {
-		txStatesMutex.Lock()
-		defer txStatesMutex.Unlock()
-
 		for {
 			state, exists := txStates[nextLogIdx]
 			if !exists || !state.submitted {
@@ -258,6 +256,7 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 				utils.RecoverPanic(options.Logger, "scenario.processNextTxFn", nil)
 
 				// Mark transaction as done
+				txStatesMutex.Lock()
 				state.done = true
 
 				// If not submitted yet, mark as submitted to unblock logging
@@ -265,6 +264,7 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 					state.submitted = true
 					processPendingLogs()
 				}
+				txStatesMutex.Unlock()
 
 				pendingWg.Done()
 				pendingCount.Add(-1)
@@ -276,6 +276,9 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 			params := &ProcessNextTxParams{
 				TxIdx: txIdx,
 				NotifySubmitted: func() {
+					txStatesMutex.Lock()
+					defer txStatesMutex.Unlock()
+
 					if state.submitted {
 						return
 					}
@@ -284,18 +287,28 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 					processPendingLogs()
 				},
 				OrderedLogCb: func(logcb func()) {
-					// If already submitted, process logs immediately
+					txStatesMutex.Lock()
 					if state.submitted {
+						// Already submitted, so ordered logging has passed this
+						// transaction: run the callback immediately.
+						txStatesMutex.Unlock()
 						logcb()
-					} else {
-						state.logCb = append(state.logCb, logcb)
+
+						return
 					}
+
+					state.logCb = append(state.logCb, logcb)
+					txStatesMutex.Unlock()
 				},
 			}
 
 			err := options.ProcessNextTxFn(ctx, params)
 
-			if err != nil || state.submitted {
+			txStatesMutex.Lock()
+			submitted := state.submitted
+			txStatesMutex.Unlock()
+
+			if err != nil || submitted {
 				txCount.Add(1)
 			}
 

--- a/scenario/txscenario.go
+++ b/scenario/txscenario.go
@@ -128,7 +128,7 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 	}
 	limiter := rate.NewLimiter(initialRate, 1)
 
-	isErrorMode := false
+	isErrorMode := atomic.Bool{}
 	errorLimiter := rate.NewLimiter(rate.Limit(0.5), 1) // 2 sec interval when in error mode
 
 	// Subscribe to block updates for stats reporting
@@ -211,7 +211,7 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 			continue
 		}
 
-		if isErrorMode {
+		if isErrorMode.Load() {
 			if err := errorLimiter.Wait(ctx); err != nil {
 				if ctx.Err() != nil {
 					break
@@ -313,9 +313,9 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 			}
 
 			if err == ErrNoClients {
-				isErrorMode = true
-			} else if isErrorMode {
-				isErrorMode = false
+				isErrorMode.Store(true)
+			} else {
+				isErrorMode.CompareAndSwap(true, false)
 			}
 		}(txIdx, state)
 

--- a/scenario/txscenario.go
+++ b/scenario/txscenario.go
@@ -253,8 +253,6 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 
 		go func(txIdx uint64, state *txState) {
 			defer func() {
-				utils.RecoverPanic(options.Logger, "scenario.processNextTxFn", nil)
-
 				// Mark transaction as done
 				txStatesMutex.Lock()
 				state.done = true
@@ -272,6 +270,12 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 					pendingCond.Signal()
 				}
 			}()
+
+			// recover only stops an unwinding panic when the recovering function
+			// is deferred directly, so this must not be moved into the teardown
+			// closure above. Deferred last, it runs first and recovers before the
+			// teardown executes.
+			defer utils.RecoverPanic(options.Logger, "scenario.processNextTxFn", nil)
 
 			params := &ProcessNextTxParams{
 				TxIdx: txIdx,

--- a/scenario/txscenario_test.go
+++ b/scenario/txscenario_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -106,5 +107,261 @@ func TestOrderedLoggingInOrder(t *testing.T) {
 		if v != uint64(i) {
 			t.Fatalf("ordered log out of order at position %d: got %d", i, v)
 		}
+	}
+}
+
+// TestScenarioOrderedLogAfterSubmit verifies that a log callback registered
+// after the transaction has been submitted runs immediately instead of being
+// buffered.
+func TestScenarioOrderedLogAfterSubmit(t *testing.T) {
+	var logged atomic.Uint64
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := RunTransactionScenario(ctx, TransactionScenarioOptions{
+		TotalCount: 100,
+		Throughput: 60000,
+		Logger:     discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			params.NotifySubmitted()
+			params.OrderedLogCb(func() {
+				logged.Add(1)
+			})
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+	if logged.Load() != 100 {
+		t.Fatalf("expected 100 log callbacks, got %d", logged.Load())
+	}
+}
+
+// TestScenarioTimeout runs an unbounded scenario with a timeout and verifies
+// that it stops on its own once the timeout elapses.
+func TestScenarioTimeout(t *testing.T) {
+	var processed atomic.Uint64
+	start := time.Now()
+
+	err := RunTransactionScenario(context.Background(), TransactionScenarioOptions{
+		TotalCount: 0,
+		Throughput: 60000,
+		Timeout:    300 * time.Millisecond,
+		Logger:     discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			params.NotifySubmitted()
+			processed.Add(1)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+	if processed.Load() == 0 {
+		t.Fatal("expected transactions to be processed before the timeout")
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("scenario did not stop after the timeout (ran %v)", elapsed)
+	}
+}
+
+// TestScenarioMaxPendingLimit verifies that no more than MaxPending
+// transactions are processed concurrently.
+func TestScenarioMaxPendingLimit(t *testing.T) {
+	const total = 12
+	const maxPending = 3
+
+	var inFlight, maxObserved atomic.Int64
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := RunTransactionScenario(ctx, TransactionScenarioOptions{
+		TotalCount: total,
+		Throughput: 60000,
+		MaxPending: maxPending,
+		Logger:     discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			current := inFlight.Add(1)
+			for {
+				peak := maxObserved.Load()
+				if current <= peak || maxObserved.CompareAndSwap(peak, current) {
+					break
+				}
+			}
+
+			time.Sleep(10 * time.Millisecond)
+			inFlight.Add(-1)
+			params.NotifySubmitted()
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+	if peak := maxObserved.Load(); peak > maxPending {
+		t.Fatalf("observed %d concurrent transactions, limit is %d", peak, maxPending)
+	}
+}
+
+// TestScenarioMaxPendingCancel verifies that a scenario blocked on the
+// pending limit stops when its context is cancelled.
+func TestScenarioMaxPendingCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{}, 1)
+	done := make(chan error, 1)
+
+	go func() {
+		done <- RunTransactionScenario(ctx, TransactionScenarioOptions{
+			TotalCount: 0,
+			Throughput: 60000,
+			MaxPending: 1,
+			Logger:     discardLogger(),
+			ProcessNextTxFn: func(txCtx context.Context, _ *ProcessNextTxParams) error {
+				select {
+				case started <- struct{}{}:
+				default:
+				}
+				<-txCtx.Done()
+				return txCtx.Err()
+			},
+		})
+	}()
+
+	<-started
+	// Give the main loop time to block on the pending limit before cancelling
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("scenario error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("scenario did not stop after context cancellation")
+	}
+}
+
+// TestScenarioClientErrorRecovery verifies that a transaction failing with
+// ErrNoClients puts the scenario into error mode and that it recovers once
+// transactions succeed again.
+func TestScenarioClientErrorRecovery(t *testing.T) {
+	var succeeded atomic.Uint64
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := RunTransactionScenario(ctx, TransactionScenarioOptions{
+		TotalCount: 4,
+		Throughput: 240, // paced so each result lands before the next transaction starts
+		Logger:     discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			if params.TxIdx == 0 {
+				return ErrNoClients
+			}
+
+			params.NotifySubmitted()
+			succeeded.Add(1)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+	if count := succeeded.Load(); count < 2 || count > 3 {
+		t.Fatalf("expected 2-3 successful transactions after error recovery, got %d", count)
+	}
+}
+
+// TestScenarioPanicRecovery verifies that a panicking transaction handler
+// does not crash the scenario and that processing continues afterwards.
+func TestScenarioPanicRecovery(t *testing.T) {
+	var succeeded atomic.Uint64
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := RunTransactionScenario(ctx, TransactionScenarioOptions{
+		TotalCount: 3,
+		Throughput: 240, // paced so each result lands before the next transaction starts
+		Logger:     discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			if params.TxIdx == 0 {
+				panic("transaction handler panic")
+			}
+
+			params.NotifySubmitted()
+			succeeded.Add(1)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+	if succeeded.Load() < 2 {
+		t.Fatalf("expected the scenario to continue after a panic, got %d successful transactions", succeeded.Load())
+	}
+}
+
+// TestScenarioNoAwaitTransactions verifies that the scenario returns without
+// waiting for in-flight transactions when NoAwaitTransactions is set.
+func TestScenarioNoAwaitTransactions(t *testing.T) {
+	release := make(chan struct{})
+	finished := sync.WaitGroup{}
+	finished.Add(2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := RunTransactionScenario(ctx, TransactionScenarioOptions{
+		TotalCount:          2,
+		Throughput:          60000,
+		NoAwaitTransactions: true,
+		Logger:              discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			defer finished.Done()
+			params.NotifySubmitted()
+			<-release
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+
+	// The scenario returned while both transactions are still blocked;
+	// release them and wait so no goroutines outlive the test.
+	close(release)
+	finished.Wait()
+}
+
+// TestScenarioThroughputIncrement runs a scenario with a periodic throughput
+// increase and verifies that it keeps processing transactions.
+func TestScenarioThroughputIncrement(t *testing.T) {
+	var processed atomic.Uint64
+
+	err := RunTransactionScenario(context.Background(), TransactionScenarioOptions{
+		TotalCount:                  0,
+		Throughput:                  60, // 5 tx/s at the default 12s slot time
+		MaxPending:                  3,
+		ThroughputIncrementInterval: 1,
+		Timeout:                     2200 * time.Millisecond,
+		Logger:                      discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			params.NotifySubmitted()
+			processed.Add(1)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+	if processed.Load() < 5 {
+		t.Fatalf("expected at least 5 transactions to be processed, got %d", processed.Load())
 	}
 }

--- a/scenario/txscenario_test.go
+++ b/scenario/txscenario_test.go
@@ -1,0 +1,110 @@
+package scenario
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func discardLogger() *logrus.Entry {
+	lg := logrus.New()
+	lg.SetOutput(io.Discard)
+	return lg.WithField("test", "txscenario")
+}
+
+// TestTransactionStateReleased runs a large number of transactions through the
+// scenario and checks that per-transaction bookkeeping does not accumulate. A
+// leak would show up as live heap objects growing roughly in step with the
+// number of processed transactions.
+func TestTransactionStateReleased(t *testing.T) {
+	const total = 20000
+
+	var baseline, peak uint64
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := RunTransactionScenario(ctx, TransactionScenarioOptions{
+		TotalCount: total,
+		Throughput: 60000, // paced so only a few transactions are in flight at a time
+		MaxPending: 0,
+		Logger:     discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			params.NotifySubmitted()
+			switch params.TxIdx {
+			case 2000:
+				runtime.GC()
+				var m runtime.MemStats
+				runtime.ReadMemStats(&m)
+				baseline = m.HeapObjects
+			case total - 1:
+				runtime.GC()
+				var m runtime.MemStats
+				runtime.ReadMemStats(&m)
+				peak = m.HeapObjects
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+	if baseline == 0 || peak == 0 {
+		t.Fatalf("measurements not captured (baseline=%d peak=%d)", baseline, peak)
+	}
+
+	growth := int64(peak) - int64(baseline)
+	if growth > total/4 {
+		t.Fatalf("live heap objects grew by %d over %d transactions; per-transaction state is not being released", growth, total-2000)
+	}
+	t.Logf("live heap objects grew by %d over %d transactions (bounded)", growth, total-2000)
+}
+
+// TestOrderedLoggingInOrder verifies that ordered log callbacks still fire
+// exactly once, in submission order, so the cleanup change does not affect
+// ordered logging.
+func TestOrderedLoggingInOrder(t *testing.T) {
+	const total = 1000
+
+	var mu sync.Mutex
+	order := make([]uint64, 0, total)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := RunTransactionScenario(ctx, TransactionScenarioOptions{
+		TotalCount: total,
+		Throughput: 60000,
+		MaxPending: 0,
+		Logger:     discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, params *ProcessNextTxParams) error {
+			idx := params.TxIdx
+			params.OrderedLogCb(func() {
+				mu.Lock()
+				order = append(order, idx)
+				mu.Unlock()
+			})
+			params.NotifySubmitted()
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != total {
+		t.Fatalf("expected %d ordered log callbacks, got %d", total, len(order))
+	}
+	for i, v := range order {
+		if v != uint64(i) {
+			t.Fatalf("ordered log out of order at position %d: got %d", i, v)
+		}
+	}
+}

--- a/scenario/types_test.go
+++ b/scenario/types_test.go
@@ -1,0 +1,42 @@
+package scenario
+
+import (
+	"testing"
+)
+
+func TestPluginDescriptorGetAllScenarios(t *testing.T) {
+	d1 := &Descriptor{Name: "one"}
+	d2 := &Descriptor{Name: "two"}
+	d3 := &Descriptor{Name: "three"}
+	d4 := &Descriptor{Name: "four"}
+
+	plugin := &PluginDescriptor{
+		Name: "test-plugin",
+		Categories: []*Category{
+			{
+				Name:        "cat1",
+				Descriptors: []*Descriptor{d1},
+				Children: []*Category{
+					{Name: "sub1", Descriptors: []*Descriptor{d2, d3}},
+				},
+			},
+			{Name: "cat2", Descriptors: []*Descriptor{d4}},
+		},
+	}
+
+	all := plugin.GetAllScenarios()
+	if len(all) != 4 {
+		t.Fatalf("expected 4 scenarios across nested categories, got %d", len(all))
+	}
+
+	expected := []string{"one", "two", "three", "four"}
+	for i, desc := range all {
+		if desc.Name != expected[i] {
+			t.Fatalf("expected scenario %q at position %d, got %q", expected[i], i, desc.Name)
+		}
+	}
+
+	if got := (&PluginDescriptor{}).GetAllScenarios(); len(got) != 0 {
+		t.Fatalf("expected no scenarios for empty plugin descriptor, got %d", len(got))
+	}
+}

--- a/scenarios/blob-average/blobaverage.go
+++ b/scenarios/blob-average/blobaverage.go
@@ -297,13 +297,18 @@ outer:
 
 			go func(txIdx uint64, blobsInTx int64) {
 				defer func() {
-					utils.RecoverPanic(s.logger, "blobaverage.sendBlobTx", nil)
 					pendingWg.Done()
 					pendingCount.Add(-1)
 					if pendingCond != nil {
 						pendingCond.Signal()
 					}
 				}()
+
+				// recover only stops an unwinding panic when the recovering function
+				// is deferred directly, so this must not be moved into the teardown
+				// closure above. Deferred last, it runs first and recovers before the
+				// teardown executes.
+				defer utils.RecoverPanic(s.logger, "blobaverage.sendBlobTx", nil)
 
 				receiptChan, tx, client, wallet, txVersion, err := s.sendBlobTx(ctx, txIdx)
 				logger := s.logger

--- a/spamoor/txpool.go
+++ b/spamoor/txpool.go
@@ -309,9 +309,9 @@ func (pool *TxPool) GetRegisteredWallet(address common.Address) *Wallet {
 // sequentially. Also triggers stale transaction processing when new blocks arrive.
 // Runs until the context is cancelled and recovers from panics with logging.
 func (pool *TxPool) runTxPoolLoop() {
-	defer func() {
-		utils.RecoverPanic(pool.options.Logger, "TxPool.runTxPoolLoop", pool.runTxPoolLoop)
-	}()
+	// recover only stops an unwinding panic when the recovering function is
+	// deferred directly, so utils.RecoverPanic must not be wrapped in a closure.
+	defer utils.RecoverPanic(pool.options.Logger, "TxPool.runTxPoolLoop", pool.runTxPoolLoop)
 
 	if pool.options.ExternalBlockSource != nil {
 		pool.runExternalBlockSourceLoop()
@@ -364,9 +364,9 @@ func (pool *TxPool) runTxPoolLoop() {
 }
 
 func (pool *TxPool) runExternalBlockSourceLoop() {
-	defer func() {
-		utils.RecoverPanic(pool.options.Logger, "TxPool.runExternalBlockSourceLoop", pool.runExternalBlockSourceLoop)
-	}()
+	// recover only stops an unwinding panic when the recovering function is
+	// deferred directly, so utils.RecoverPanic must not be wrapped in a closure.
+	defer utils.RecoverPanic(pool.options.Logger, "TxPool.runExternalBlockSourceLoop", pool.runExternalBlockSourceLoop)
 
 	blockChan := pool.options.ExternalBlockSource.SubscribeBlocks(pool.options.Context, 10)
 	highestBlockNumber := uint64(0)
@@ -421,9 +421,9 @@ func (pool *TxPool) runExternalBlockSourceLoop() {
 // It listens for block number updates and processes stale confirmations for all
 // active wallets. Runs until the context is cancelled and recovers from panics.
 func (pool *TxPool) processStaleTransactionsLoop() {
-	defer func() {
-		utils.RecoverPanic(pool.options.Logger, "TxPool.processStaleTransactionsLoop", pool.processStaleTransactionsLoop)
-	}()
+	// recover only stops an unwinding panic when the recovering function is
+	// deferred directly, so utils.RecoverPanic must not be wrapped in a closure.
+	defer utils.RecoverPanic(pool.options.Logger, "TxPool.processStaleTransactionsLoop", pool.processStaleTransactionsLoop)
 
 	for {
 		select {


### PR DESCRIPTION
# Release transaction state once logged & fix data races in RunTransactionScenario

Branch: `pk910/fix-txscenario-races` (based on #250)

## Problem

`RunTransactionScenario` tracks per-transaction bookkeeping in a map (`txStates`) to deliver ordered log callbacks. An entry was only removed when the ordered-log processor reached it while the transaction was already done. In the normal flow — `NotifySubmitted()` called first, transaction finishing later — the log cursor advances past the entry while it is still in flight and never revisits it, so the entry is never deleted. Long-running spammers leak one map entry per transaction (~10k live heap objects per 20k transactions in testing).

Additionally, the per-transaction state fields (`submitted`, `logCb`, `done`) were written by the worker goroutine and its `NotifySubmitted`/`OrderedLogCb` callbacks without holding `txStatesMutex`, while `processPendingLogs` read them under the mutex from other goroutines. These pre-existing data races were latent because the `scenario` package had no tests; the new tests trip the race detector on exactly these accesses, which would fail CI (`go test -race`).

## Fix

**Memory leak** (from #250 by @damilolaedwards): delete the `txStates` entry as soon as its ordered logs have run, instead of only when the transaction happens to be done at that moment. The worker goroutine keeps its own reference to the state for the rest of its teardown, so removing it from the map does not affect in-flight work, and ordered logging is unchanged.

**Data races** (new commits on top): move all `txState` field access under `txStatesMutex`. `processPendingLogs` now requires the caller to hold the lock (Go mutexes are not reentrant), so `NotifySubmitted` and the worker teardown mark the transaction as submitted and drain pending logs under a single lock acquisition — which also closes the check-then-act window between reading `submitted` and processing logs. `OrderedLogCb` keeps running immediate callbacks outside the lock, matching previous behavior for buffered vs. immediate callbacks.

`isErrorMode` — a plain bool written by worker goroutines and read by the main scenario loop without synchronization — is converted to `atomic.Bool` as well.

**Broken panic recovery** (found by the new tests): `utils.RecoverPanic` was called *inside* deferred closures, but `recover()` only stops an unwinding panic when the recovering function is deferred directly. A panic in `ProcessNextTxFn` therefore escaped the goroutine and crashed the whole process instead of being logged and swallowed. `utils.RecoverPanic` is now deferred directly (after the teardown closure where one exists, so it runs first during unwinding). The same defect existed in the `spamoor/txpool.go` loop recoveries (which never restarted their loops on panic) and the blob-average scenario worker — all occurrences are fixed.

**Test suite**: unit tests for the whole `scenario` package covering its common usage patterns — registry registration and native-scenario protection, reflection-based config validation with typo suggestions, YAML parsing into option structs, throughput tracker averaging including ring buffer wraparound, receipt channel waiting, plugin descriptor flattening, and the `RunTransactionScenario` behaviors scenarios rely on (ordered logging, timeout, `MaxPending` limiting and cancellation, `ErrNoClients` error mode recovery, panic recovery, `NoAwaitTransactions`, throughput increments).

## Testing

- `TestTransactionStateReleased` (from #250): runs 20,000 transactions and asserts live heap objects stay bounded. Fails on master with ~10k leaked objects; passes with the fix.
- `TestOrderedLoggingInOrder` (from #250): asserts ordered log callbacks still fire exactly once, in submission order.
- `go test -race -count=3 ./scenario/` passes (fails on #250 as submitted — the tests expose the pre-existing races).
- The panic recovery test crashes the test binary without the `RecoverPanic` fix, confirming the bug.
- `gofmt`, `go vet`, `staticcheck` clean.

## Notes

- Supersedes #250; includes its commit unchanged to preserve authorship. Credit to @damilolaedwards for finding and fixing the leak and adding test coverage.
- `state.done` is now write-only after the unconditional delete and could be dropped in a follow-up.
