### PR TITLE
tx-fuzz: replace stuck transactions to keep wallets live

### DIFF
--- a/scenarios/tx-fuzz/README.md
+++ b/scenarios/tx-fuzz/README.md
@@ -47,6 +47,7 @@ spamoor tx-fuzz [flags]
 - `--tipfee` - Max tip per gas in gwei (default: 2)
 - `--gaslimit` - Gas limit per transaction (default: 500000)
 - `--rebroadcast` - Seconds to wait before rebroadcasting (default: 30)
+- `--unstuck-time` - Seconds to wait for a fuzzed tx before replacing it with a cancel tx to free the nonce (default: 60, 0 disables)
 - `--timeout` - Maximum duration to run (e.g. '1h', '30m', '5s')
 
 ### Fuzzing Configuration

--- a/scenarios/tx-fuzz/README.md
+++ b/scenarios/tx-fuzz/README.md
@@ -23,24 +23,37 @@ spamoor tx-fuzz [flags]
 
 - **Transaction type** — legacy (0), access list (2930), dynamic fee (1559),
   blob (4844), set code (7702), chosen uniformly from the enabled set per tx.
-- **Calldata / initcode** — mixed empty / small / large random payloads.
-- **Recipient** — recoverable child wallets, the zero address, precompile
-  addresses, system contracts (beacon roots, withdrawal/consolidation queues,
-  history storage), and fully random addresses. Legacy/2930/1559 are sometimes
-  contract creations (`to == nil`).
-- **Access lists** — random EIP-2930 tuples (often empty).
+- **Calldata / initcode** — mixed empty / small / large random payloads, with an
+  occasional near-`--max-call-data` payload.
+- **Recipient** — recoverable child wallets, contracts deployed by earlier
+  fuzzed creations (so calldata executes against real bytecode), the zero
+  address, precompile addresses, system contracts (beacon roots,
+  withdrawal/consolidation queues, history storage), and fully random
+  addresses. Legacy/2930/1559 are sometimes contract creations (`to == nil`).
+- **Value** — zero, 1 wei, or a small random amount (up to ~0.001 ETH).
+  Meaningful value is only sent to pool wallets so funds stay reclaimable.
+- **Gas limit** — fuzzed across buckets: the exact intrinsic-gas floor
+  (out-of-gas on the first unit of work), floor plus small slack, mid-range, and
+  the configured `--gaslimit` cap. Always at or above the intrinsic floor so
+  every tx stays includable.
+- **Access lists** — random EIP-2930 tuples (often empty), with an occasional
+  near-limit list (max entries, each fully loaded with storage keys).
 - **Authorizations** — fuzzed EIP-7702 auth lists signed with throwaway keys
   (decoupled from pool nonce accounting), with mixed valid/garbage chain IDs and
-  nonces.
+  nonces. A fraction of setcode txs additionally carry an authorization that
+  actually *applies* (fresh ephemeral authority with nonce 0, real chain id,
+  delegate with code) and call the authority so the delegated code executes.
 - **Blobs** — random blob sidecars plus known edge cases (all-zero, repeated,
-  duplicate commitments).
+  duplicate commitments), occasionally the full `--max-blobs` budget.
 
 ## Configuration
 
 ### Volume Control (either -c or -t required)
 - `-c, --count` - Total number of transactions to send
 - `-t, --throughput` - Transactions to send per slot (default: 50)
-- `--max-pending` - Maximum number of pending transactions (default: 100)
+- `--max-pending` - Maximum number of concurrent pending submissions (default: 0
+  = auto-sized from throughput and wallet count). Workers no longer hold a
+  pending slot until confirmation, so throughput is governed by `-t` alone.
 
 ### Transaction Settings
 - `--basefee` - Max fee per gas in gwei (default: 20)
@@ -58,6 +71,9 @@ spamoor tx-fuzz [flags]
 - `--max-access-list` - Maximum access list entries and storage keys (default: 5)
 - `--max-auth-list` - Maximum EIP-7702 authorizations per setcode tx (default: 5)
 - `--max-blobs` - Maximum blob sidecars per blob tx (default: 3)
+- `--max-blob-tx-per-slot` - Maximum blob txs submitted per slot (default: 4,
+  0 = unlimited). Excess blob txs are re-fuzzed as non-blob txs instead of
+  hoarding pending slots on blob capacity.
 
 ### Blob Format (EIP-4844 / EIP-7594)
 Blob txs use the v0 KZG-proof sidecar before Fulu and the v1 (cell-proof) wrapper
@@ -71,6 +87,11 @@ when available, otherwise from this flag.
 
 ### Wallet Management
 - `--max-wallets` - Maximum number of child wallets to use
+
+The wallet pool is partitioned into a blob and a non-blob class: each wallet
+only ever sends one class of transactions. go-ethereum reserves every account
+to a single subpool, so mixing blob and non-blob txs on one wallet would cause
+"address already reserved" rejections.
 
 ### Client Settings
 - `--client-group` - Client group to use for sending transactions

--- a/scenarios/tx-fuzz/fuzzer.go
+++ b/scenarios/tx-fuzz/fuzzer.go
@@ -4,6 +4,7 @@ import (
 	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
+	"math"
 	"math/rand"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -64,6 +65,7 @@ type fuzzedTx struct {
 	to         *common.Address // nil => contract creation (only for legacy/accesslist/dynfee)
 	data       []byte
 	value      *uint256.Int
+	gas        uint64
 	accessList types.AccessList
 	authList   []types.SetCodeAuthorization
 	blobRefs   [][]string
@@ -74,13 +76,18 @@ type fuzzer struct {
 	seed         []byte
 	chainID      uint64
 	enabledKinds []txKind
+	nonBlobKinds []txKind // enabledKinds without kindBlob (fallback when blob rate limited)
 	maxCallData  int
 	maxAccessLen int
 	maxAuthList  int
 	maxBlobs     int
+	gasLimit     uint64 // configured per-tx gas cap; fuzzed gas never exceeds it
 	// poolAddrs are recoverable target addresses (child wallets) so value-bearing
 	// or simple call txs don't permanently burn funds to unspendable addresses.
 	poolAddrs func() []common.Address
+	// deployedAddrs are contracts successfully deployed by earlier fuzzed creation
+	// txs; targeting them makes fuzzed calldata execute against real bytecode.
+	deployedAddrs func() []common.Address
 }
 
 // rngFor returns a deterministic RNG for a given transaction index, derived from
@@ -95,9 +102,24 @@ func (f *fuzzer) rngFor(txIdx uint64) *rand.Rand {
 
 // generate builds a fuzzed transaction envelope for the given index.
 func (f *fuzzer) generate(txIdx uint64) *fuzzedTx {
+	return f.generateFromKinds(txIdx, f.enabledKinds)
+}
+
+// generateNonBlob regenerates the envelope for txIdx restricted to the enabled
+// non-blob kinds. Used when the blob rate limiter rejects a blob tx.
+func (f *fuzzer) generateNonBlob(txIdx uint64) *fuzzedTx {
+	if len(f.nonBlobKinds) == 0 {
+		return f.generate(txIdx)
+	}
+	return f.generateFromKinds(txIdx, f.nonBlobKinds)
+}
+
+// generateFromKinds builds a fuzzed transaction envelope for the given index,
+// picking the envelope type from the given kind set.
+func (f *fuzzer) generateFromKinds(txIdx uint64, kinds []txKind) *fuzzedTx {
 	rng := f.rngFor(txIdx)
 
-	kind := f.enabledKinds[rng.Intn(len(f.enabledKinds))]
+	kind := kinds[rng.Intn(len(kinds))]
 	tx := &fuzzedTx{
 		kind:  kind,
 		value: uint256.NewInt(0),
@@ -107,8 +129,25 @@ func (f *fuzzer) generate(txIdx uint64) *fuzzedTx {
 	// Blob and setcode txs require a non-nil recipient; the others may be
 	// contract creations (~20% of the time) to also fuzz the creation path.
 	requiresTo := kind == kindBlob || kind == kindSetCode
+	recoverable := false
 	if requiresTo || rng.Intn(5) != 0 {
-		tx.to = f.fuzzTarget(rng)
+		tx.to, recoverable = f.fuzzTarget(rng)
+	}
+
+	// Value: only send meaningful value when the target is a pool wallet, so the
+	// funds move between child wallets and stay reclaimable. Non-recoverable
+	// targets occasionally get 1 wei to still exercise value-transfer paths.
+	if recoverable {
+		switch rng.Intn(4) {
+		case 0:
+			// keep zero
+		case 1:
+			tx.value = uint256.NewInt(1)
+		default:
+			tx.value = uint256.NewInt(uint64(rng.Int63n(1_000_000_000_000_000)) + 1) // up to ~0.001 ETH
+		}
+	} else if tx.to != nil && rng.Intn(20) == 0 {
+		tx.value = uint256.NewInt(1)
 	}
 
 	// Access lists apply to all typed txs (2930/1559/4844/7702). Legacy can't carry one.
@@ -119,22 +158,98 @@ func (f *fuzzer) generate(txIdx uint64) *fuzzedTx {
 	switch kind {
 	case kindSetCode:
 		tx.authList = f.fuzzAuthList(rng)
+		// ~1/3 of setcode txs additionally carry an authorization that actually
+		// applies (fresh ephemeral authority, nonce 0, real chain id, delegate
+		// with code) and call the authority itself so the delegated code
+		// executes within this very tx.
+		if rng.Intn(3) == 0 {
+			if auth, authority := f.applyingAuth(rng); auth != nil {
+				tx.authList = append(tx.authList, *auth)
+				tx.to = authority
+				tx.value = uint256.NewInt(0) // authority key is discarded; value would be burned
+			}
+		}
 	case kindBlob:
 		tx.blobRefs = f.fuzzBlobRefs(rng)
 	}
 
+	tx.gas = f.fuzzGas(rng, tx)
+
 	return tx
 }
 
-// fuzzCallData produces a calldata/initcode payload with a mix of shapes:
-// empty, small, and larger random blobs up to the configured cap.
-func (f *fuzzer) fuzzCallData(rng *rand.Rand) []byte {
+// intrinsicGasFloor approximates the minimum gas a tx of this shape needs to be
+// accepted by the pool (intrinsic gas). Staying at or above it keeps every
+// fuzzed tx includable; the "exact floor" gas bucket then exercises
+// out-of-gas-on-first-op paths without producing invalid transactions.
+func intrinsicGasFloor(tx *fuzzedTx) uint64 {
+	gas := uint64(21000)
+	gas += 16 * uint64(len(tx.data))
+	for _, tuple := range tx.accessList {
+		gas += 2400
+		gas += 1900 * uint64(len(tuple.StorageKeys))
+	}
+	if tx.to == nil {
+		// contract creation: base creation cost + EIP-3860 per-word initcode cost
+		gas += 32000
+		gas += 2 * ((uint64(len(tx.data)) + 31) / 32)
+	}
+	// EIP-7702 charges PER_EMPTY_ACCOUNT_COST per authorization tuple
+	gas += 25000 * uint64(len(tx.authList))
+	return gas
+}
+
+// fuzzGas picks a gas limit across buckets: the exact intrinsic floor, floor
+// plus a little slack, a mid-range value, and the configured cap. The result is
+// always >= the intrinsic floor (so the tx stays includable) and <= the
+// configured gas limit cap whenever the cap itself is above the floor.
+func (f *fuzzer) fuzzGas(rng *rand.Rand, tx *fuzzedTx) uint64 {
+	floor := intrinsicGasFloor(tx)
+	gasCap := f.gasLimit
+	if gasCap <= floor {
+		return floor
+	}
+
+	var gas uint64
 	switch rng.Intn(8) {
+	case 0:
+		gas = floor // exact intrinsic floor: any execution work runs out of gas
+	case 1, 2:
+		gas = floor + uint64(rng.Int63n(50000)) + 1 // floor plus small slack
+	case 3, 4:
+		span := gasCap - floor
+		if span > math.MaxInt64 {
+			span = math.MaxInt64
+		}
+		gas = floor + uint64(rng.Int63n(int64(span))) // anywhere in range
+	default:
+		gas = gasCap
+	}
+	if gas > gasCap {
+		gas = gasCap
+	}
+	return gas
+}
+
+// fuzzCallData produces a calldata/initcode payload with a mix of shapes:
+// empty, small, near-limit, and larger random blobs up to the configured cap.
+func (f *fuzzer) fuzzCallData(rng *rand.Rand) []byte {
+	switch rng.Intn(10) {
 	case 0:
 		return nil // empty calldata
 	case 1, 2:
 		// small payload (e.g. 4-byte selector + a word or two)
 		return randomBytes(rng, rng.Intn(36))
+	case 3:
+		// near the configured maximum (low probability so it doesn't dominate)
+		if f.maxCallData <= 0 {
+			return nil
+		}
+		slack := rng.Intn(33)
+		if slack >= f.maxCallData {
+			slack = 0
+		}
+		return randomBytes(rng, f.maxCallData-slack)
 	default:
 		if f.maxCallData <= 0 {
 			return nil
@@ -144,32 +259,44 @@ func (f *fuzzer) fuzzCallData(rng *rand.Rand) []byte {
 }
 
 // fuzzTarget picks a recipient address across a spread of interesting buckets:
-// recoverable pool wallets, the zero address, low precompile addresses, system
-// contracts, and fully random addresses.
-func (f *fuzzer) fuzzTarget(rng *rand.Rand) *common.Address {
+// recoverable pool wallets, contracts deployed by earlier fuzzed creations, the
+// zero address, low precompile addresses, system contracts, and fully random
+// addresses. The second return value is true only for pool-wallet targets, i.e.
+// when value sent to the address stays reclaimable.
+func (f *fuzzer) fuzzTarget(rng *rand.Rand) (*common.Address, bool) {
 	switch rng.Intn(10) {
-	case 0, 1, 2, 3:
+	case 0, 1, 2:
 		// recoverable child wallet (keeps any value transfers reclaimable)
 		if addrs := f.poolAddrs(); len(addrs) > 0 {
 			a := addrs[rng.Intn(len(addrs))]
-			return &a
+			return &a, true
 		}
 		fallthrough
-	case 4:
+	case 3:
 		a := common.Address{}
-		return &a // zero address
-	case 5, 6:
+		return &a, false // zero address
+	case 4, 5:
+		// a contract deployed by an earlier fuzzed creation tx, so the fuzzed
+		// calldata executes against real bytecode
+		if f.deployedAddrs != nil {
+			if addrs := f.deployedAddrs(); len(addrs) > 0 {
+				a := addrs[rng.Intn(len(addrs))]
+				return &a, false
+			}
+		}
+		fallthrough
+	case 6:
 		// a precompile address (0x01 .. 0x11)
 		a := common.Address{}
 		a[19] = byte(1 + rng.Intn(0x11))
-		return &a
+		return &a, false
 	case 7:
 		a := systemAddresses[rng.Intn(len(systemAddresses))]
-		return &a
+		return &a, false
 	default:
 		var a common.Address
 		copy(a[:], randomBytes(rng, 20))
-		return &a
+		return &a, false
 	}
 }
 
@@ -180,13 +307,22 @@ func (f *fuzzer) fuzzAccessList(rng *rand.Rand) types.AccessList {
 		return nil // ~50% empty
 	}
 
+	// occasionally emit the near-limit shape: max entries, each fully loaded
+	nearLimit := rng.Intn(10) == 0
+
 	n := rng.Intn(f.maxAccessLen) + 1
+	if nearLimit {
+		n = f.maxAccessLen
+	}
 	al := make(types.AccessList, 0, n)
 	for i := 0; i < n; i++ {
 		var addr common.Address
 		copy(addr[:], randomBytes(rng, 20))
 
 		keyCount := rng.Intn(f.maxAccessLen + 1)
+		if nearLimit {
+			keyCount = f.maxAccessLen
+		}
 		keys := make([]common.Hash, 0, keyCount)
 		for j := 0; j < keyCount; j++ {
 			var key common.Hash
@@ -211,7 +347,7 @@ func (f *fuzzer) fuzzAuthList(rng *rand.Rand) []types.SetCodeAuthorization {
 	auths := make([]types.SetCodeAuthorization, 0, n)
 	for i := 0; i < n; i++ {
 		// delegate target address (random, system, or zero)
-		delegate := f.fuzzTarget(rng)
+		delegate, _ := f.fuzzTarget(rng)
 
 		// chainID: mostly the real chain (so some auths can actually apply),
 		// occasionally 0 (valid for any chain) or a random garbage value.
@@ -243,6 +379,42 @@ func (f *fuzzer) fuzzAuthList(rng *rand.Rand) []types.SetCodeAuthorization {
 	return auths
 }
 
+// applyingAuth builds an EIP-7702 authorization that actually applies on chain:
+// the authority is a fresh ephemeral key (on-chain nonce 0, never part of the
+// managed wallet pool, so the nonce bump from applying it cannot corrupt pool
+// nonce tracking), the chain id is the real one, and the delegate is an address
+// known to hold code (a fuzz-deployed contract if available, else a system
+// contract). Returns the signed authorization plus the authority address so the
+// caller can target it and execute the delegated code in the same tx.
+func (f *fuzzer) applyingAuth(rng *rand.Rand) (*types.SetCodeAuthorization, *common.Address) {
+	var delegate common.Address
+	if f.deployedAddrs != nil {
+		if addrs := f.deployedAddrs(); len(addrs) > 0 {
+			delegate = addrs[rng.Intn(len(addrs))]
+		}
+	}
+	if delegate == (common.Address{}) {
+		// system contracts with code (skip the last entry, params.SystemAddress,
+		// which has no code deployed)
+		delegate = systemAddresses[rng.Intn(len(systemAddresses)-1)]
+	}
+
+	sk, err := crypto.GenerateKey()
+	if err != nil {
+		return nil, nil
+	}
+	authority := crypto.PubkeyToAddress(sk.PublicKey)
+	signed, err := types.SignSetCode(sk, types.SetCodeAuthorization{
+		ChainID: *uint256.NewInt(f.chainID),
+		Address: delegate,
+		Nonce:   0, // fresh key => on-chain nonce 0 => the authorization applies
+	})
+	if err != nil {
+		return nil, nil
+	}
+	return &signed, &authority
+}
+
 // fuzzBlobRefs produces 1..maxBlobs blob references using spamoor's blob ref DSL,
 // mixing fully-random blobs with a few known edge cases (all-zero, repeated,
 // duplicate commitments).
@@ -250,6 +422,9 @@ func (f *fuzzer) fuzzBlobRefs(rng *rand.Rand) [][]string {
 	count := 1
 	if f.maxBlobs > 1 {
 		count = rng.Intn(f.maxBlobs) + 1
+		if rng.Intn(10) == 0 {
+			count = f.maxBlobs // occasionally use the full blob budget
+		}
 	}
 
 	refs := make([][]string, count)

--- a/scenarios/tx-fuzz/tx_fuzz.go
+++ b/scenarios/tx-fuzz/tx_fuzz.go
@@ -5,9 +5,11 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/big"
 	mathrand "math/rand"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	"golang.org/x/time/rate"
 
 	"github.com/ethpandaops/spamoor/scenario"
 	"github.com/ethpandaops/spamoor/spamoor"
@@ -40,13 +43,14 @@ type ScenarioOptions struct {
 	UnstuckTime uint64  `yaml:"unstuck_time"` // seconds to wait for a tx before replacing it to free the nonce (0 = disabled)
 
 	// Fuzzing specific options
-	TxTypes       string `yaml:"tx_types"`        // comma list: legacy,accesslist,dynfee,blob,setcode (or "all")
-	PayloadSeed   string `yaml:"payload_seed"`    // optional hex seed for reproducible fuzzing
-	TxIdOffset    uint64 `yaml:"tx_id_offset"`    // start fuzzing from a specific txID
-	MaxCallData   uint64 `yaml:"max_call_data"`   // maximum calldata/initcode size in bytes
-	MaxAccessList uint64 `yaml:"max_access_list"` // maximum access list entries / storage keys
-	MaxAuthList   uint64 `yaml:"max_auth_list"`   // maximum EIP-7702 authorizations per tx
-	MaxBlobs      uint64 `yaml:"max_blobs"`       // maximum blob sidecars per blob tx
+	TxTypes          string `yaml:"tx_types"`             // comma list: legacy,accesslist,dynfee,blob,setcode (or "all")
+	PayloadSeed      string `yaml:"payload_seed"`         // optional hex seed for reproducible fuzzing
+	TxIdOffset       uint64 `yaml:"tx_id_offset"`         // start fuzzing from a specific txID
+	MaxCallData      uint64 `yaml:"max_call_data"`        // maximum calldata/initcode size in bytes
+	MaxAccessList    uint64 `yaml:"max_access_list"`      // maximum access list entries / storage keys
+	MaxAuthList      uint64 `yaml:"max_auth_list"`        // maximum EIP-7702 authorizations per tx
+	MaxBlobs         uint64 `yaml:"max_blobs"`            // maximum blob sidecars per blob tx
+	MaxBlobTxPerSlot uint64 `yaml:"max_blob_tx_per_slot"` // maximum blob txs submitted per slot (0 = unlimited)
 
 	// Blob format (EIP-4844 / EIP-7594) options
 	BlobV1Percent  uint64                   `yaml:"blob_v1_percent"` // % of blob txs sent with the v1 (cell-proof) wrapper after Fulu
@@ -59,6 +63,27 @@ type Scenario struct {
 	walletPool *spamoor.WalletPool
 	fuzzer     *fuzzer
 	seed       string
+
+	// blobWalletCount is the size of the blob wallet partition: wallets with
+	// index [0, blobWalletCount) send blob txs, the rest send everything else.
+	// go-ethereum reserves each account to a single subpool, so mixing blob and
+	// non-blob txs on one wallet causes "address already reserved" failures.
+	blobWalletCount uint64
+	// blobOnly is true when kindBlob is the only enabled tx kind.
+	blobOnly bool
+
+	// blobLimiter rate-limits blob tx submissions (see --max-blob-tx-per-slot);
+	// nil = unlimited.
+	blobLimiter *rate.Limiter
+
+	// confirmWg tracks detached receipt-await and unstuck goroutines so Run can
+	// drain them after the submission loop finishes.
+	confirmWg sync.WaitGroup
+
+	// registry of contracts successfully deployed by fuzzed creation txs, used
+	// as call targets and 7702 delegates. Capped at maxDeployedContracts.
+	deployedMtx       sync.Mutex
+	deployedContracts []common.Address
 }
 
 // unstuckMaxTries bounds how many escalating-fee replacement attempts are made
@@ -66,11 +91,15 @@ type Scenario struct {
 // rebroadcast/gap-fill take over.
 const unstuckMaxTries = 5
 
+// maxDeployedContracts caps the deployed-contract registry; once full, the
+// oldest entries are evicted.
+const maxDeployedContracts = 1024
+
 var ScenarioName = "tx-fuzz"
 var ScenarioDefaultOptions = ScenarioOptions{
 	TotalCount:  0,
 	Throughput:  50,
-	MaxPending:  100,
+	MaxPending:  0,
 	MaxWallets:  0,
 	Rebroadcast: 30,
 	BaseFee:     20,
@@ -81,13 +110,14 @@ var ScenarioDefaultOptions = ScenarioOptions{
 	LogTxs:      false,
 	UnstuckTime: 60,
 
-	TxTypes:       "all",
-	PayloadSeed:   "",
-	TxIdOffset:    0,
-	MaxCallData:   1024,
-	MaxAccessList: 5,
-	MaxAuthList:   5,
-	MaxBlobs:      3,
+	TxTypes:          "all",
+	PayloadSeed:      "",
+	TxIdOffset:       0,
+	MaxCallData:      1024,
+	MaxAccessList:    5,
+	MaxAuthList:      5,
+	MaxBlobs:         3,
+	MaxBlobTxPerSlot: 4,
 
 	BlobV1Percent:  100,
 	FuluActivation: 0, // 0 = Fulu active since genesis -> send v1 (cell-proof) blobs by default
@@ -110,7 +140,7 @@ func newScenario(logger logrus.FieldLogger) scenario.Scenario {
 func (s *Scenario) Flags(flags *pflag.FlagSet) error {
 	flags.Uint64VarP(&s.options.TotalCount, "count", "c", ScenarioDefaultOptions.TotalCount, "Total number of fuzzed transactions to send")
 	flags.Uint64VarP(&s.options.Throughput, "throughput", "t", ScenarioDefaultOptions.Throughput, "Number of fuzzed transactions to send per slot")
-	flags.Uint64Var(&s.options.MaxPending, "max-pending", ScenarioDefaultOptions.MaxPending, "Maximum number of pending transactions")
+	flags.Uint64Var(&s.options.MaxPending, "max-pending", ScenarioDefaultOptions.MaxPending, "Maximum number of pending transactions (0 = auto-size from throughput and wallet count)")
 	flags.Uint64Var(&s.options.MaxWallets, "max-wallets", ScenarioDefaultOptions.MaxWallets, "Maximum number of child wallets to use")
 	flags.Uint64Var(&s.options.Rebroadcast, "rebroadcast", ScenarioDefaultOptions.Rebroadcast, "Enable reliable rebroadcast with unlimited retries and exponential backoff")
 	flags.Float64Var(&s.options.BaseFee, "basefee", ScenarioDefaultOptions.BaseFee, "Max fee per gas to use in transactions (in gwei)")
@@ -130,6 +160,7 @@ func (s *Scenario) Flags(flags *pflag.FlagSet) error {
 	flags.Uint64Var(&s.options.MaxAccessList, "max-access-list", ScenarioDefaultOptions.MaxAccessList, "Maximum access list entries and storage keys per entry")
 	flags.Uint64Var(&s.options.MaxAuthList, "max-auth-list", ScenarioDefaultOptions.MaxAuthList, "Maximum EIP-7702 authorizations per setcode tx")
 	flags.Uint64Var(&s.options.MaxBlobs, "max-blobs", ScenarioDefaultOptions.MaxBlobs, "Maximum blob sidecars per blob tx")
+	flags.Uint64Var(&s.options.MaxBlobTxPerSlot, "max-blob-tx-per-slot", ScenarioDefaultOptions.MaxBlobTxPerSlot, "Maximum blob txs to submit per slot, excess blob txs are re-fuzzed as non-blob txs (0 = unlimited)")
 	flags.Uint64Var(&s.options.BlobV1Percent, "blob-v1-percent", ScenarioDefaultOptions.BlobV1Percent, "Percentage of blob transactions to send with the v1 (cell-proof) wrapper format after Fulu")
 	flags.Uint64Var((*uint64)(&s.options.FuluActivation), "fulu-activation", uint64(ScenarioDefaultOptions.FuluActivation), "Unix timestamp of the Fulu activation")
 
@@ -191,14 +222,47 @@ func (s *Scenario) Init(options *scenario.Options) error {
 		}
 	}
 
+	// Partition the wallets into a blob and a non-blob class. go-ethereum
+	// reserves each account to a single subpool, so a wallet must only ever send
+	// one class of transactions to avoid "address already reserved" failures.
+	walletCount := s.walletPool.GetConfiguredWalletCount()
+	blobEnabled := false
+	for _, k := range enabledKinds {
+		if k == kindBlob {
+			blobEnabled = true
+		}
+	}
+	s.blobOnly = blobEnabled && len(enabledKinds) == 1
+	switch {
+	case s.blobOnly:
+		s.blobWalletCount = walletCount
+	case blobEnabled:
+		s.blobWalletCount = walletCount / uint64(len(enabledKinds))
+		if s.blobWalletCount < 1 {
+			s.blobWalletCount = 1
+		}
+	default:
+		s.blobWalletCount = 0
+	}
+
+	nonBlobKinds := make([]txKind, 0, len(enabledKinds))
+	for _, k := range enabledKinds {
+		if k != kindBlob {
+			nonBlobKinds = append(nonBlobKinds, k)
+		}
+	}
+
 	s.fuzzer = &fuzzer{
-		chainID:      s.walletPool.GetChainId().Uint64(),
-		enabledKinds: enabledKinds,
-		maxCallData:  int(s.options.MaxCallData),
-		maxAccessLen: int(s.options.MaxAccessList),
-		maxAuthList:  int(s.options.MaxAuthList),
-		maxBlobs:     int(s.options.MaxBlobs),
-		poolAddrs:    s.poolAddresses,
+		chainID:       s.walletPool.GetChainId().Uint64(),
+		enabledKinds:  enabledKinds,
+		nonBlobKinds:  nonBlobKinds,
+		maxCallData:   int(s.options.MaxCallData),
+		maxAccessLen:  int(s.options.MaxAccessList),
+		maxAuthList:   int(s.options.MaxAuthList),
+		maxBlobs:      int(s.options.MaxBlobs),
+		gasLimit:      s.options.GasLimit,
+		poolAddrs:     s.poolAddresses,
+		deployedAddrs: s.deployedAddresses,
 	}
 
 	return nil
@@ -231,6 +295,16 @@ func (s *Scenario) Run(ctx context.Context) error {
 		}
 	}
 
+	if s.options.Throughput > 0 && s.options.MaxPending > 0 && s.options.Throughput > s.options.MaxPending {
+		s.logger.Warnf("--throughput (%d) is higher than --max-pending (%d); the pending cap makes the requested throughput unreachable", s.options.Throughput, s.options.MaxPending)
+	}
+
+	// Blob txs are additionally rate limited: chain blob capacity is far lower
+	// than tx capacity, so unrestricted blob fuzzing would hoard pending slots.
+	if s.options.MaxBlobTxPerSlot > 0 {
+		s.blobLimiter = rate.NewLimiter(rate.Limit(float64(s.options.MaxBlobTxPerSlot)/scenario.GlobalSlotDuration.Seconds()), int(s.options.MaxBlobTxPerSlot))
+	}
+
 	var timeout time.Duration
 	var err error
 	if s.options.Timeout != "" {
@@ -249,12 +323,13 @@ func (s *Scenario) Run(ctx context.Context) error {
 	}).Info("Starting transaction-layer fuzzer scenario")
 
 	err = scenario.RunTransactionScenario(ctx, scenario.TransactionScenarioOptions{
-		TotalCount: s.options.TotalCount,
-		Throughput: s.options.Throughput,
-		MaxPending: maxPending,
-		Timeout:    timeout,
-		WalletPool: s.walletPool,
-		Logger:     s.logger.(*logrus.Entry),
+		TotalCount:          s.options.TotalCount,
+		Throughput:          s.options.Throughput,
+		MaxPending:          maxPending,
+		Timeout:             timeout,
+		WalletPool:          s.walletPool,
+		Logger:              s.logger.(*logrus.Entry),
+		NoAwaitTransactions: true,
 		ProcessNextTxFn: func(ctx context.Context, params *scenario.ProcessNextTxParams) error {
 			logger := s.logger
 			receiptChan, tx, client, wallet, kind, err := s.sendFuzzedTx(ctx, params.TxIdx)
@@ -280,40 +355,141 @@ func (s *Scenario) Run(ctx context.Context) error {
 			})
 
 			if receiptChan != nil {
-				// Bound the wait: a fuzzed tx may be accepted into a mempool but
-				// never mined (invalid execution, pool eviction, blob/non-blob
-				// account reservation conflicts, ...). The unstuck goroutine
-				// spawned in sendFuzzedTx replaces such a tx at its nonce so the
-				// wallet keeps moving; this deadline is a backstop so the slot is
-				// freed even if every replacement also fails to land.
-				waitCtx := ctx
-				if s.options.UnstuckTime > 0 {
-					var cancel context.CancelFunc
-					deadline := time.Duration(s.options.UnstuckTime*(unstuckMaxTries+2)) * time.Second
-					waitCtx, cancel = context.WithTimeout(ctx, deadline)
-					defer cancel()
-				}
-				if _, werr := receiptChan.Wait(waitCtx); werr != nil {
-					if ctx.Err() != nil {
-						return werr
+				// Await the receipt in a detached goroutine instead of blocking
+				// this worker: the pending slot is released right after
+				// submission, so MaxPending bounds concurrent submissions and the
+				// throughput limiter alone governs the send rate.
+				//
+				// The wait is bounded: a fuzzed tx may be accepted into a mempool
+				// but never mined (invalid execution, pool eviction, ...). The
+				// unstuck goroutine spawned in sendFuzzedTx replaces such a tx at
+				// its nonce so the wallet keeps moving; this deadline is a
+				// backstop so the goroutine exits even if every replacement also
+				// fails to land.
+				s.confirmWg.Add(1)
+				go func(txIdx uint64, kind string, tx *types.Transaction, logger logrus.FieldLogger) {
+					defer s.confirmWg.Done()
+
+					waitCtx := ctx
+					if s.options.UnstuckTime > 0 {
+						var cancel context.CancelFunc
+						deadline := time.Duration(s.options.UnstuckTime*(unstuckMaxTries+2)) * time.Second
+						waitCtx, cancel = context.WithTimeout(ctx, deadline)
+						defer cancel()
 					}
-					// per-tx deadline hit (scenario still running): give up on this
-					// tx and free the slot rather than block the whole scenario.
-					logger.Warnf("fuzz tx %6d.0 (%s) not confirmed within unstuck deadline, freeing slot", params.TxIdx+1, kind)
-				}
+
+					receipt, werr := receiptChan.Wait(waitCtx)
+					if werr != nil {
+						if ctx.Err() == nil {
+							logger.Warnf("fuzz tx %6d.0 (%s) not confirmed within unstuck deadline", txIdx+1, kind)
+						}
+						return
+					}
+
+					// Track successfully deployed contracts so later fuzzed txs
+					// can call them and 7702 auths can delegate to them.
+					if tx != nil && tx.To() == nil && receipt != nil &&
+						receipt.Status == types.ReceiptStatusSuccessful &&
+						receipt.ContractAddress != (common.Address{}) {
+						s.recordDeployedContract(receipt.ContractAddress)
+					}
+				}(params.TxIdx, kind, tx, logger)
 			}
 
 			return err
 		},
 	})
 
+	// Graceful drain: wait for the detached confirm/unstuck goroutines to finish
+	// before returning. The waits are bounded by the unstuck deadline and abort
+	// early on context cancellation.
+	confirmDone := make(chan struct{})
+	go func() {
+		s.confirmWg.Wait()
+		close(confirmDone)
+	}()
+	select {
+	case <-confirmDone:
+	case <-ctx.Done():
+	}
+
 	return err
+}
+
+// recordDeployedContract adds a successfully deployed contract address to the
+// registry (evicting the oldest entry once the cap is reached).
+func (s *Scenario) recordDeployedContract(addr common.Address) {
+	s.deployedMtx.Lock()
+	defer s.deployedMtx.Unlock()
+	if len(s.deployedContracts) >= maxDeployedContracts {
+		s.deployedContracts = s.deployedContracts[1:]
+	}
+	s.deployedContracts = append(s.deployedContracts, addr)
+}
+
+// deployedAddresses returns a snapshot of the deployed-contract registry.
+func (s *Scenario) deployedAddresses() []common.Address {
+	s.deployedMtx.Lock()
+	defer s.deployedMtx.Unlock()
+	return append([]common.Address(nil), s.deployedContracts...)
+}
+
+// pickWallet selects a wallet for the given tx kind from the matching wallet
+// partition (blob wallets are the index range [0, blobWalletCount), non-blob
+// wallets the rest), choosing the wallet with the lowest pending tx depth and
+// breaking ties deterministically by txIdx.
+func (s *Scenario) pickWallet(kind txKind, txIdx uint64) *spamoor.Wallet {
+	wallets := s.walletPool.GetAllWallets()
+	count := uint64(len(wallets))
+	if count == 0 {
+		return nil
+	}
+
+	blobCount := s.blobWalletCount
+	if blobCount > count {
+		blobCount = count
+	}
+
+	var start, end uint64
+	if kind == kindBlob {
+		start, end = 0, blobCount
+	} else {
+		start, end = blobCount, count
+	}
+	if end <= start {
+		// empty partition (e.g. single-wallet pool): fall back to all wallets
+		start, end = 0, count
+	}
+
+	partitionSize := end - start
+	offset := txIdx % partitionSize
+	var best *spamoor.Wallet
+	bestDepth := uint64(math.MaxUint64)
+	for i := uint64(0); i < partitionSize; i++ {
+		wallet := wallets[start+(offset+i)%partitionSize]
+		if wallet == nil {
+			continue
+		}
+		depth := wallet.GetNonce() - wallet.GetConfirmedNonce()
+		if depth < bestDepth {
+			bestDepth = depth
+			best = wallet
+		}
+	}
+	return best
 }
 
 func (s *Scenario) sendFuzzedTx(ctx context.Context, txIdx uint64) (scenario.ReceiptChan, *types.Transaction, *spamoor.Client, *spamoor.Wallet, string, error) {
 	ftx := s.fuzzer.generate(txIdx + s.options.TxIdOffset)
 
-	wallet := s.walletPool.GetWallet(spamoor.SelectWalletByPendingTxCount, int(txIdx))
+	// Blob txs are rate limited separately (chain blob capacity is far lower
+	// than tx capacity). When the slot's blob budget is exhausted, re-fuzz the
+	// envelope as a non-blob kind instead of blocking the worker.
+	if ftx.kind == kindBlob && !s.blobOnly && s.blobLimiter != nil && !s.blobLimiter.Allow() {
+		ftx = s.fuzzer.generateNonBlob(txIdx + s.options.TxIdOffset)
+	}
+
+	wallet := s.pickWallet(ftx.kind, txIdx)
 	if wallet == nil {
 		return nil, nil, nil, nil, ftx.kind.String(), fmt.Errorf("no wallet available")
 	}
@@ -380,7 +556,11 @@ func (s *Scenario) sendFuzzedTx(ctx context.Context, txIdx uint64) (scenario.Rec
 	// Watch it and, once it looks stuck, replace it at its nonce with a cheap
 	// cancel tx so the wallet's nonce advances regardless of the original's fate.
 	if s.options.UnstuckTime > 0 {
-		go s.unstuckLoop(ctx, wallet, tx, confirmed)
+		s.confirmWg.Add(1)
+		go func() {
+			defer s.confirmWg.Done()
+			s.unstuckLoop(ctx, wallet, tx, confirmed)
+		}()
 	}
 
 	return receiptChan, tx, client, wallet, ftx.kind.String(), nil
@@ -395,10 +575,19 @@ func (s *Scenario) sendFuzzedTx(ctx context.Context, txIdx uint64) (scenario.Rec
 func (s *Scenario) unstuckLoop(ctx context.Context, wallet *spamoor.Wallet, stuckTx *types.Transaction, confirmed *atomic.Bool) {
 	nonce := stuckTx.Nonce()
 	for try := 0; try < unstuckMaxTries; try++ {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(time.Duration(s.options.UnstuckTime) * time.Second):
+		// Wait UnstuckTime before (re)placing, but poll for early confirmation
+		// so this goroutine (and the scenario's final drain) doesn't linger
+		// after the tx has already mined.
+		waitEnd := time.Now().Add(time.Duration(s.options.UnstuckTime) * time.Second)
+		for time.Now().Before(waitEnd) {
+			if confirmed.Load() || wallet.GetConfirmedNonce() > nonce {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second):
+			}
 		}
 
 		// The original (or a prior replacement) confirmed, or the wallet already
@@ -485,12 +674,22 @@ func (s *Scenario) sendCancelTx(ctx context.Context, wallet *spamoor.Wallet, stu
 // buildTx turns a fuzzed envelope into a concrete signed transaction of the
 // matching type using the wallet's managed-nonce build methods.
 func (s *Scenario) buildTx(wallet *spamoor.Wallet, ftx *fuzzedTx, feeCap, tipCap *big.Int) (*types.Transaction, error) {
+	// Use the fuzzed gas value, clamped to the current block gas limit (the
+	// configured --gaslimit already caps it at generation time).
+	gas := ftx.gas
+	if gas == 0 {
+		gas = s.options.GasLimit
+	}
+	if blockLimit := s.walletPool.GetTxPool().GetCurrentGasLimit(); blockLimit > 0 && gas > blockLimit {
+		gas = blockLimit
+	}
+
 	fee := uint256.MustFromBig(feeCap)
 	tip := uint256.MustFromBig(tipCap)
 	meta := &txbuilder.TxMetadata{
 		GasFeeCap:  fee,
 		GasTipCap:  tip,
-		Gas:        s.options.GasLimit,
+		Gas:        gas,
 		To:         ftx.to,
 		Value:      ftx.value,
 		Data:       ftx.data,

--- a/scenarios/tx-fuzz/tx_fuzz.go
+++ b/scenarios/tx-fuzz/tx_fuzz.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	mathrand "math/rand"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -36,6 +37,7 @@ type ScenarioOptions struct {
 	Timeout     string  `yaml:"timeout"`
 	ClientGroup string  `yaml:"client_group"`
 	LogTxs      bool    `yaml:"log_txs"`
+	UnstuckTime uint64  `yaml:"unstuck_time"` // seconds to wait for a tx before replacing it to free the nonce (0 = disabled)
 
 	// Fuzzing specific options
 	TxTypes       string `yaml:"tx_types"`        // comma list: legacy,accesslist,dynfee,blob,setcode (or "all")
@@ -59,6 +61,11 @@ type Scenario struct {
 	seed       string
 }
 
+// unstuckMaxTries bounds how many escalating-fee replacement attempts are made
+// to clear a single stuck nonce before giving up and letting the pool's own
+// rebroadcast/gap-fill take over.
+const unstuckMaxTries = 5
+
 var ScenarioName = "tx-fuzz"
 var ScenarioDefaultOptions = ScenarioOptions{
 	TotalCount:  0,
@@ -72,6 +79,7 @@ var ScenarioDefaultOptions = ScenarioOptions{
 	Timeout:     "",
 	ClientGroup: "",
 	LogTxs:      false,
+	UnstuckTime: 60,
 
 	TxTypes:       "all",
 	PayloadSeed:   "",
@@ -113,6 +121,7 @@ func (s *Scenario) Flags(flags *pflag.FlagSet) error {
 	flags.StringVar(&s.options.Timeout, "timeout", ScenarioDefaultOptions.Timeout, "Timeout for the scenario (e.g. '1h', '30m', '5s') - empty means no timeout")
 	flags.StringVar(&s.options.ClientGroup, "client-group", ScenarioDefaultOptions.ClientGroup, "Client group to use for sending transactions")
 	flags.BoolVar(&s.options.LogTxs, "log-txs", ScenarioDefaultOptions.LogTxs, "Log all submitted transactions")
+	flags.Uint64Var(&s.options.UnstuckTime, "unstuck-time", ScenarioDefaultOptions.UnstuckTime, "Seconds to wait for a fuzzed tx before replacing it with a cancel tx to free the nonce (0 disables)")
 
 	flags.StringVar(&s.options.TxTypes, "tx-types", ScenarioDefaultOptions.TxTypes, "Comma-separated tx types to fuzz: legacy,accesslist,dynfee,blob,setcode (or 'all')")
 	flags.StringVar(&s.options.PayloadSeed, "payload-seed", ScenarioDefaultOptions.PayloadSeed, "Custom hex seed for reproducible fuzzing (e.g. 0x1234abcd, empty means random)")
@@ -271,8 +280,26 @@ func (s *Scenario) Run(ctx context.Context) error {
 			})
 
 			if receiptChan != nil {
-				if _, err := receiptChan.Wait(ctx); err != nil {
-					return err
+				// Bound the wait: a fuzzed tx may be accepted into a mempool but
+				// never mined (invalid execution, pool eviction, blob/non-blob
+				// account reservation conflicts, ...). The unstuck goroutine
+				// spawned in sendFuzzedTx replaces such a tx at its nonce so the
+				// wallet keeps moving; this deadline is a backstop so the slot is
+				// freed even if every replacement also fails to land.
+				waitCtx := ctx
+				if s.options.UnstuckTime > 0 {
+					var cancel context.CancelFunc
+					deadline := time.Duration(s.options.UnstuckTime*(unstuckMaxTries+2)) * time.Second
+					waitCtx, cancel = context.WithTimeout(ctx, deadline)
+					defer cancel()
+				}
+				if _, werr := receiptChan.Wait(waitCtx); werr != nil {
+					if ctx.Err() != nil {
+						return werr
+					}
+					// per-tx deadline hit (scenario still running): give up on this
+					// tx and free the slot rather than block the whole scenario.
+					logger.Warnf("fuzz tx %6d.0 (%s) not confirmed within unstuck deadline, freeing slot", params.TxIdx+1, kind)
 				}
 			}
 
@@ -311,11 +338,13 @@ func (s *Scenario) sendFuzzedTx(ctx context.Context, txIdx uint64) (scenario.Rec
 	}
 
 	receiptChan := make(scenario.ReceiptChan, 1)
+	confirmed := &atomic.Bool{}
 	sendOpts := &spamoor.SendTransactionOptions{
 		Client:      client,
 		ClientGroup: s.options.ClientGroup,
 		Rebroadcast: s.options.Rebroadcast > 0,
 		OnComplete: func(tx *types.Transaction, receipt *types.Receipt, err error) {
+			confirmed.Store(true)
 			receiptChan <- receipt
 		},
 	}
@@ -346,7 +375,111 @@ func (s *Scenario) sendFuzzedTx(ctx context.Context, txIdx uint64) (scenario.Rec
 		return nil, tx, client, wallet, ftx.kind.String(), err
 	}
 
+	// The tx submitted fine, but fuzzed txs frequently never mine (invalid
+	// execution, pool eviction, blob/non-blob account reservation conflicts).
+	// Watch it and, once it looks stuck, replace it at its nonce with a cheap
+	// cancel tx so the wallet's nonce advances regardless of the original's fate.
+	if s.options.UnstuckTime > 0 {
+		go s.unstuckLoop(ctx, wallet, tx, confirmed)
+	}
+
 	return receiptChan, tx, client, wallet, ftx.kind.String(), nil
+}
+
+// unstuckLoop waits for the fuzzed tx to confirm; if it doesn't within
+// UnstuckTime, it repeatedly submits a fee-bumped cancel transaction at the same
+// nonce until either the nonce clears or the try budget is exhausted. This is the
+// key liveness guarantee for the fuzzer: because a fuzzed tx may be accepted by a
+// node yet never be includable, the only way to keep a wallet usable is to
+// forcibly replace the stuck nonce rather than wait on an outcome that never comes.
+func (s *Scenario) unstuckLoop(ctx context.Context, wallet *spamoor.Wallet, stuckTx *types.Transaction, confirmed *atomic.Bool) {
+	nonce := stuckTx.Nonce()
+	for try := 0; try < unstuckMaxTries; try++ {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Duration(s.options.UnstuckTime) * time.Second):
+		}
+
+		// The original (or a prior replacement) confirmed, or the wallet already
+		// mined past this nonce: nothing to unstuck.
+		if confirmed.Load() || wallet.GetConfirmedNonce() > nonce {
+			return
+		}
+
+		if err := s.sendCancelTx(ctx, wallet, stuckTx, try); err != nil {
+			s.logger.WithField("wallet", s.walletPool.GetWalletName(wallet.GetAddress())).
+				Debugf("unstuck attempt %d for nonce %d failed: %v", try+1, nonce, err)
+		} else {
+			s.logger.WithField("wallet", s.walletPool.GetWalletName(wallet.GetAddress())).
+				Debugf("submitted unstuck cancel tx for nonce %d (attempt %d)", nonce, try+1)
+		}
+	}
+}
+
+// sendCancelTx replaces the stuck tx at its nonce with a minimal, definitely-
+// mineable transaction carrying aggressively bumped fees. A blob tx can only be
+// replaced by another blob tx (go-ethereum keeps blob and non-blob txs in
+// separate subpools), so the cancel matches the stuck tx's pool class.
+func (s *Scenario) sendCancelTx(ctx context.Context, wallet *spamoor.Wallet, stuckTx *types.Transaction, try int) error {
+	client := s.walletPool.GetClient(
+		spamoor.WithClientSelectionMode(spamoor.SelectClientRandom),
+		spamoor.WithClientGroup(s.options.ClientGroup),
+	)
+	if client == nil {
+		return fmt.Errorf("no client available")
+	}
+
+	baseFeeWei, tipFeeWei := spamoor.ResolveFees(s.options.BaseFee, s.options.TipFee, s.options.BaseFeeWei, s.options.TipFeeWei)
+	feeCap, tipCap, err := s.walletPool.GetSuggestedFees(client, baseFeeWei, tipFeeWei)
+	if err != nil {
+		return err
+	}
+
+	// Escalate fees each attempt so replacements clear go-ethereum's price-bump
+	// requirement (>=10% for regular txs, >=100% for blob fees) even against a
+	// previous replacement.
+	bump := big.NewInt(int64(1) << uint(try+1)) // 2x, 4x, 8x, ...
+	feeCap = new(big.Int).Mul(feeCap, bump)
+	tipCap = new(big.Int).Mul(tipCap, bump)
+
+	nonce := stuckTx.Nonce()
+	to := wallet.GetAddress()
+
+	var cancelTx *types.Transaction
+	if stuckTx.Type() == types.BlobTxType {
+		meta := &txbuilder.TxMetadata{
+			GasFeeCap:  uint256.MustFromBig(feeCap),
+			GasTipCap:  uint256.MustFromBig(tipCap),
+			BlobFeeCap: uint256.MustFromBig(feeCap),
+			Gas:        21000,
+			To:         &to,
+			Value:      uint256.NewInt(0),
+		}
+		blobTx, berr := txbuilder.BuildBlobTx(meta, [][]string{{"random:full"}})
+		if berr != nil {
+			return berr
+		}
+		cancelTx, err = wallet.ReplaceBlobTx(blobTx, nonce)
+	} else {
+		txData := &types.DynamicFeeTx{
+			GasFeeCap: feeCap,
+			GasTipCap: tipCap,
+			Gas:       21000,
+			To:        &to,
+			Value:     big.NewInt(0),
+		}
+		cancelTx, err = wallet.ReplaceDynamicFeeTx(txData, nonce)
+	}
+	if err != nil {
+		return err
+	}
+
+	return s.walletPool.GetTxPool().SendTransaction(ctx, wallet, cancelTx, &spamoor.SendTransactionOptions{
+		Client:      client,
+		ClientGroup: s.options.ClientGroup,
+		Rebroadcast: true,
+	})
 }
 
 // buildTx turns a fuzzed envelope into a concrete signed transaction of the


### PR DESCRIPTION
## Problem

The `tx-fuzz` scenario reliably wedges after ~5–10 minutes — the daemon shows `submitted=0`, a flat `pending` count, and `confirmed=0` block after block while still marked *Running*.

Root cause: a fuzzer inevitably produces transactions that a node **accepts into its mempool but never mines** — invalid execution, mempool eviction, or (the big one) go-ethereum's **blob/non-blob account reservation**. The fuzzer draws a random tx type (legacy/2930/1559/**4844**/7702) per tx from a *shared* wallet pool, so blob and non-blob txs land on the same wallets; geth reserves each account exclusively for either the blob subpool or the legacy subpool, so the "wrong type" tx is rejected and leaves a nonce gap that the pool's non-blob gap-filler can't clear while the wallet is blob-reserved.

The scenario waited on every submitted tx's receipt via `receiptChan.Wait(ctx)` with **no per-tx deadline**. Never-confirming txs parked their goroutines forever; once enough accumulated (or `TotalCount` was reached and the drain began), the scenario stopped submitting entirely and hung.

As discussed, you can't know up front whether a fuzzed tx is invalid or merely stuck — so the only robust fix is to **replace a stuck tx after a timeout, regardless of outcome** (this is what the standalone tx-fuzz tool does, and what the sibling `tx-fuzz-invalid` scenario already does out-of-pool).

## Fix (scoped to `scenarios/tx-fuzz/` only)

- After a tx is submitted, a background `unstuckLoop` watches it. If it hasn't confirmed within `--unstuck-time` seconds (default **60**, `0` disables), it replaces the tx **at its nonce** with a minimal, definitely-mineable cancel tx so the wallet's nonce advances no matter what happened to the original.
  - Blob txs are replaced with a blob cancel, everything else with a dynfee self-transfer — matching geth's subpool class so the replacement is accepted.
  - Fees escalate across up to 5 attempts (2×, 4×, …) to clear geth's replacement price-bump rules (≥10% regular, ≥100% blob).
- The per-tx receipt wait is now **bounded** as a backstop, so even a tx that can't be unstuck frees its slot instead of blocking the whole scenario.

## Testing

- `go build -tags with_blob_v1,ckzg ./...` ✅
- `gofmt -l`, `go vet`, `staticcheck` all clean ✅
- Ready to validate on `glamsterdam-devnet-6` where the wedge reproduces.