### PR TITLE
Count every processed transaction toward TotalCount

### DIFF
--- a/scenario/txscenario.go
+++ b/scenario/txscenario.go
@@ -308,13 +308,12 @@ func RunTransactionScenario(ctx context.Context, options TransactionScenarioOpti
 
 			err := options.ProcessNextTxFn(ctx, params)
 
-			txStatesMutex.Lock()
-			submitted := state.submitted
-			txStatesMutex.Unlock()
-
-			if err != nil || submitted {
-				txCount.Add(1)
-			}
+			// Every returned call counts toward TotalCount, regardless of whether it
+			// submitted a transaction, failed, or completed without ever calling
+			// NotifySubmitted. Counting only submissions and errors let a
+			// ProcessNextTxFn that finishes successfully without calling
+			// NotifySubmitted run forever, since the count never advanced for it.
+			txCount.Add(1)
 
 			if err == ErrNoClients {
 				isErrorMode.Store(true)

--- a/scenario/txscenario_test.go
+++ b/scenario/txscenario_test.go
@@ -365,3 +365,35 @@ func TestScenarioThroughputIncrement(t *testing.T) {
 		t.Fatalf("expected at least 5 transactions to be processed, got %d", processed.Load())
 	}
 }
+
+// TestTotalCountHonoredWithoutNotifySubmitted verifies that a ProcessNextTxFn
+// which completes successfully without ever calling NotifySubmitted still
+// counts toward TotalCount. Some scenarios handle all of their own logging
+// and never call NotifySubmitted, and the scenario must still stop at the
+// configured count for them instead of running until the context ends.
+func TestTotalCountHonoredWithoutNotifySubmitted(t *testing.T) {
+	const total = 50
+
+	var calls atomic.Int64
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := RunTransactionScenario(ctx, TransactionScenarioOptions{
+		TotalCount: total,
+		Throughput: 12000, // ~1000/s at the default 12s slot time
+		Logger:     discardLogger(),
+		ProcessNextTxFn: func(_ context.Context, _ *ProcessNextTxParams) error {
+			calls.Add(1)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("scenario error: %v", err)
+	}
+
+	n := calls.Load()
+	if n > total+20 {
+		t.Fatalf("expected the run to stop around TotalCount=%d, got %d calls", total, n)
+	}
+}


### PR DESCRIPTION
RunTransactionScenario only counted a transaction toward TotalCount if it returned an error or had called NotifySubmitted. A scenario that completes successfully without ever calling NotifySubmitted (it may handle its own logging some other way) never advanced the count, so the run kept going past TotalCount instead of stopping at the configured limit. The taskrunner scenario hits this today: its --count flag does not actually bound the run.

Counts every returned call instead. Scenarios that do call NotifySubmitted are unaffected, since those calls were already being counted either way.