### PR TITLE
Make spammer start atomic to stop a concurrent double-run crash

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -587,7 +587,7 @@ func (d *Daemon) Shutdown() {
 	d.spammerMapMtx.RLock()
 	spammers := make([]*Spammer, 0, len(d.spammerMap))
 	for _, s := range d.spammerMap {
-		if s.running {
+		if s.running.Load() {
 			spammers = append(spammers, s)
 		}
 	}

--- a/daemon/spammer.go
+++ b/daemon/spammer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethpandaops/spamoor/daemon/db"
@@ -44,7 +45,7 @@ type Spammer struct {
 	walletPool     *spamoor.WalletPool
 	scenarioCtx    context.Context
 	scenarioCancel context.CancelFunc
-	running        bool
+	running        atomic.Bool
 	runningChan    chan struct{}
 	plugin         *plugin.LoadedPlugin // nil for native scenarios
 }
@@ -258,10 +259,9 @@ func (s *Spammer) runScenario() {
 		return
 	}
 
-	if s.running {
+	if !s.running.CompareAndSwap(false, true) {
 		return
 	}
-	s.running = true
 	s.daemon.spammerWg.Add(1)
 
 	if s.scenarioCancel != nil {
@@ -283,7 +283,15 @@ func (s *Spammer) runScenario() {
 		}
 
 		s.daemon.spammerWg.Done()
-		close(s.runningChan)
+
+		// Clear the running flag before releasing anything blocked on runningChan
+		// (Pause waits on it), so a Start issued right after a Pause returns never
+		// sees a stale "still running" state. Close the local channel this run
+		// created, not s.runningChan: clearing the flag above can let a new run
+		// start immediately and overwrite that field with its own channel before
+		// this defer gets to close it.
+		s.running.Store(false)
+		close(runningChan)
 
 		if s.daemon.ctx.Err() != nil {
 			return
@@ -317,7 +325,6 @@ func (s *Spammer) runScenario() {
 			s.daemon.maybeScheduleAutoRestart(s)
 		}
 
-		s.running = false
 		s.scenarioCancel()
 		s.scenarioCancel = nil
 

--- a/daemon/spammer_test.go
+++ b/daemon/spammer_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/spamoor/daemon/db"
+)
+
+func silentSpammerLogger() *logrus.Entry {
+	lg := logrus.New()
+	lg.SetOutput(io.Discard)
+	return lg.WithField("test", "spammer")
+}
+
+// newFastFailSpammer builds a Spammer whose runScenario returns almost
+// immediately with no database and no scenario lookup: the daemon context is
+// pre-cancelled and the scenario name does not exist.
+func newFastFailSpammer(d *Daemon, id int64) *Spammer {
+	return &Spammer{
+		daemon:   d,
+		logger:   silentSpammerLogger(),
+		dbEntity: &db.Spammer{ID: id, Scenario: "no-such-scenario"},
+	}
+}
+
+// TestRunScenario_ConcurrentStartDoesNotPanic drives runScenario from several
+// goroutines released at the same time, on the same spammer, over many
+// rounds. Only one call per round may pass the running guard; every other
+// call must return immediately without touching runningChan, so no round
+// should ever produce a panic or a data race.
+func TestRunScenario_ConcurrentStartDoesNotPanic(t *testing.T) {
+	dctx, dcancel := context.WithCancel(context.Background())
+	dcancel()
+	d := &Daemon{ctx: dctx}
+
+	const rounds = 500
+	const goroutines = 8
+
+	for r := 0; r < rounds; r++ {
+		s := newFastFailSpammer(d, int64(r+1))
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for g := 0; g < goroutines; g++ {
+			go func() {
+				defer wg.Done()
+				defer func() {
+					if rec := recover(); rec != nil {
+						t.Errorf("runScenario panicked: %v", rec)
+					}
+				}()
+				<-start
+				s.runScenario()
+			}()
+		}
+		close(start)
+		wg.Wait()
+	}
+}
+
+// TestRunScenario_RunningFlagClearedBeforeChannelCloses verifies that by the
+// time runScenario returns, the running flag has already been cleared.
+// Closing runningChan is what unblocks a caller waiting in Pause, so if
+// running were still true at that point, a Start issued right after Pause
+// returns could see stale state and silently do nothing.
+func TestRunScenario_RunningFlagClearedBeforeChannelCloses(t *testing.T) {
+	dctx, dcancel := context.WithCancel(context.Background())
+	dcancel()
+	d := &Daemon{ctx: dctx}
+	s := newFastFailSpammer(d, 1)
+
+	s.runScenario()
+
+	select {
+	case <-s.runningChan:
+	default:
+		t.Fatal("expected runScenario to close runningChan")
+	}
+	if s.running.Load() {
+		t.Fatal("expected running to already be false once runScenario has returned")
+	}
+}


### PR DESCRIPTION
Start launched runScenario in a goroutine with no synchronization around the already-running check. Two Start calls arriving close together could both pass the check before either set the flag, so both would proceed to set up their own runningChan and eventually both try to close it. The second close panics, and nothing recovers a panic raised after a defer's own recover has already run, so it took down the whole process.

The running flag is now an atomic bool guarded with a single compare-and-swap, so only one caller can ever win the race to start a run.

While in there, also fixed the flag being cleared after runningChan was closed instead of before. Pause unblocks as soon as the channel closes, so a Start issued right after a Pause could see the flag still true and silently do nothing. Clearing the flag first closes that window. That change on its own opened a narrower one: clearing the flag can let a new run start and overwrite the shared runningChan field before the old run gets to close it, so the close now targets the local channel each run created instead of re-reading the shared field.

Added tests covering concurrent start attempts and the flag/channel ordering.