### PR TITLE
Fix erc20_bloater running out of gas on Amsterdam

### DIFF
--- a/scenarios/statebloat/erc20_bloater/erc20_bloater.go
+++ b/scenarios/statebloat/erc20_bloater/erc20_bloater.go
@@ -247,6 +247,10 @@ func (s *Scenario) Run(ctx context.Context) error {
 	s.logger.Infof("target: %.2f GB = %d addresses (%.2f million)",
 		s.options.TargetStorageGB, targetAddresses, float64(targetAddresses)/1000000)
 
+	gasLimitPerTx, addressesPerTx := s.computeBatchParams()
+	s.logger.Infof("batch sizing: %d addresses per tx, %.2fM gas per tx (amsterdam=%v)",
+		addressesPerTx, float64(gasLimitPerTx)/1000000, s.walletPool.GetTxPool().IsAmsterdam())
+
 	// Start bloating with EIP-7825 compliant transaction splitting
 	totalTxCount := uint64(0)
 	errorCount := 0
@@ -261,12 +265,12 @@ func (s *Scenario) Run(ctx context.Context) error {
 
 		// Calculate how to split transactions for EIP-7825 compliance
 		totalTargetGas := uint64(float64(blockGasLimit) * s.options.TargetGasRatio)
-		txSplits := s.calculateTransactionSplits(totalTargetGas)
+		txSplits := s.calculateTransactionSplits(totalTargetGas, gasLimitPerTx)
 
 		// Log splitting strategy if needed
 		if len(txSplits) > 1 {
-			s.logger.Infof("splitting target gas (%.1fM) across %d transactions (fixed %.1fM gas each)",
-				float64(totalTargetGas)/1000000, len(txSplits), float64(FixedGasLimitPerTx)/1000000)
+			s.logger.Infof("splitting target gas (%.1fM) across %d transactions (%.1fM gas each)",
+				float64(totalTargetGas)/1000000, len(txSplits), float64(gasLimitPerTx)/1000000)
 		} else {
 			s.logger.Infof("block gas limit: %d, target gas: %d (%.0f%%) - single tx",
 				blockGasLimit, totalTargetGas, s.options.TargetGasRatio*100)
@@ -302,8 +306,8 @@ func (s *Scenario) Run(ctx context.Context) error {
 
 			wallet := s.walletPool.GetWallet(spamoor.SelectWalletByIndex, walletIndex)
 
-			// Use the maximum number of addresses that fit within EIP-7825 limit
-			numAddresses := uint64(MaxBloatedAddressesPerTx)
+			// Use the maximum number of addresses that fit within gasLimitPerTx
+			numAddresses := addressesPerTx
 
 			// Check if we would exceed our target addresses
 			endAddressIndex := nextAddressIndex + numAddresses
@@ -317,11 +321,11 @@ func (s *Scenario) Run(ctx context.Context) error {
 			}
 
 			s.logger.Debugf("batch %d/%d: processing %d addresses (max per tx) with %dM gas limit",
-				i+1, len(txSplits), numAddresses, FixedGasLimitPerTx/1000000)
+				i+1, len(txSplits), numAddresses, gasLimitPerTx/1000000)
 
 			// Build bloating transaction with calculated number of addresses
 			// NOTE: nextAddressIndex is already in address units (matching contract's nextStorageSlot)
-			tx, err := s.buildBloatTx(ctx, wallet, nextAddressIndex, numAddresses)
+			tx, err := s.buildBloatTx(ctx, wallet, nextAddressIndex, numAddresses, gasLimitPerTx)
 			if err != nil {
 				s.logger.Errorf("failed to build batch tx %d/%d: %v", i+1, len(txSplits), err)
 				roundSuccess = false
@@ -332,7 +336,7 @@ func (s *Scenario) Run(ctx context.Context) error {
 				tx:              tx,
 				wallet:          wallet,
 				numAddresses:    numAddresses,
-				gasLimit:        FixedGasLimitPerTx,
+				gasLimit:        gasLimitPerTx,
 				endAddressIndex: endAddressIndex,
 			})
 
@@ -340,7 +344,7 @@ func (s *Scenario) Run(ctx context.Context) error {
 				"batch":     fmt.Sprintf("%d/%d", i+1, len(txSplits)),
 				"wallet":    s.walletPool.GetWalletName(wallet.GetAddress()),
 				"addresses": numAddresses,
-				"gas_limit": FixedGasLimitPerTx,
+				"gas_limit": gasLimitPerTx,
 			}).Debugf("built bloat tx")
 
 			nextAddressIndex = endAddressIndex
@@ -448,16 +452,90 @@ func (s *Scenario) Run(ctx context.Context) error {
 	return nil
 }
 
-// calculateTransactionSplits determines how many transactions are needed for the target gas
-// Each transaction uses the fixed gas limit for simplicity and predictability
-func (s *Scenario) calculateTransactionSplits(totalTargetGas uint64) []uint64 {
-	// Simple calculation: divide total by fixed limit
-	numTxs := (totalTargetGas + FixedGasLimitPerTx - 1) / FixedGasLimitPerTx // ceiling division
+// computeBatchParams determines the per-transaction gas limit and how many
+// addresses fit within it, from the connected chain's live fork/gas state.
+func (s *Scenario) computeBatchParams() (gasLimitPerTx uint64, addressesPerTx uint64) {
+	txpool := s.walletPool.GetTxPool()
+	return calculateBatchParams(txpool.IsAmsterdam(), txpool.MaxTxGas(), txpool.GetCostPerStateByte(), s.logger)
+}
 
-	// All transactions use the same fixed gas limit
+// calculateBatchParams is the pure sizing calculation behind computeBatchParams,
+// split out so it can be tested without a live chain connection.
+//
+// Pre-Amsterdam this just returns the existing fixed constants, unchanged.
+//
+// Under Amsterdam (EIP-8037), creating a new storage slot also charges
+// state-creation gas from a second, separate budget, and a transaction only
+// receives a nonzero share of that budget once its total requested Gas
+// exceeds the EIP-7825 ceiling (utils.MaxGasLimitPerTx) - the excess becomes
+// the state-gas reservoir. A fixed, chain-agnostic gas limit at or below that
+// ceiling gets a state-gas reservoir of exactly zero, so every new slot's
+// state-creation cost spills entirely into regular gas instead, and a batch
+// sized for the old cost model runs out of gas partway through. Both values
+// are recomputed from the live per-tx gas ceiling, which is itself chain-
+// aware (TxPool.MaxTxGas reports the block gas limit on Amsterdam, since only
+// the state dimension is capped at the legacy ceiling there).
+func calculateBatchParams(isAmsterdam bool, maxTxGas uint64, costPerStateByte uint64, logger *logrus.Entry) (gasLimitPerTx uint64, addressesPerTx uint64) {
+	if !isAmsterdam {
+		return FixedGasLimitPerTx, MaxBloatedAddressesPerTx
+	}
+
+	const (
+		// Regular-gas portion of creating one new (cold) storage slot under
+		// Amsterdam's restructured SSTORE costs: the SSTORE_RESET_GAS tier,
+		// 5,000 gas, replaces the old SSTORE_SET + cold-access combination.
+		sstoreResetGas = uint64(5000)
+		// Key + value bytes charged as state-creation gas for each new slot.
+		perSlotStateBytes = uint64(64)
+		// Warm balanceOf[msg.sender] update, loop arithmetic, margin.
+		loopOverhead = uint64(400)
+		// Function dispatch, state variable reads, margin.
+		callOverhead = uint64(300000)
+	)
+
+	regularPerAddr := SlotsPerBloatCycle*sstoreResetGas + loopOverhead
+	statePerAddr := SlotsPerBloatCycle * perSlotStateBytes * costPerStateByte
+
+	if statePerAddr == 0 || maxTxGas <= utils.MaxGasLimitPerTx {
+		// Either state gas isn't actually priced, or the chain's block gas
+		// limit leaves no room to exceed the EIP-7825 ceiling at all - there is
+		// nowhere for a state-gas reservoir to come from. Fall back to the
+		// pre-Amsterdam sizing so the scenario still makes progress, just
+		// without a state-gas reservoir (everything spills into regular gas,
+		// which the pre-Amsterdam batch size stays safely under).
+		if logger != nil {
+			logger.Warnf("cannot size an Amsterdam state-gas reservoir (max tx gas %d); falling back to pre-Amsterdam batch sizing", maxTxGas)
+		}
+		return FixedGasLimitPerTx, MaxBloatedAddressesPerTx
+	}
+
+	addressesPerTx = (maxTxGas - utils.MaxGasLimitPerTx) / statePerAddr
+	if addressesPerTx == 0 {
+		addressesPerTx = 1
+	}
+	// The regular-gas need for even a large batch is tiny next to the
+	// mandatory EIP-7825 regular allotment (state gas dominates by roughly
+	// 20x per address), but guard it explicitly rather than assume it can
+	// never bind.
+	for addressesPerTx > 1 && regularPerAddr*addressesPerTx+callOverhead > utils.MaxGasLimitPerTx {
+		addressesPerTx--
+	}
+
+	gasLimitPerTx = utils.MaxGasLimitPerTx + addressesPerTx*statePerAddr
+
+	return gasLimitPerTx, addressesPerTx
+}
+
+// calculateTransactionSplits determines how many transactions are needed for the target gas.
+// Each transaction uses gasLimitPerTx for simplicity and predictability.
+func (s *Scenario) calculateTransactionSplits(totalTargetGas uint64, gasLimitPerTx uint64) []uint64 {
+	// Simple calculation: divide total by the per-tx limit
+	numTxs := (totalTargetGas + gasLimitPerTx - 1) / gasLimitPerTx // ceiling division
+
+	// All transactions use the same gas limit
 	splits := make([]uint64, numTxs)
 	for i := range splits {
-		splits[i] = FixedGasLimitPerTx
+		splits[i] = gasLimitPerTx
 	}
 
 	return splits
@@ -607,7 +685,7 @@ func (s *Scenario) deployContract(ctx context.Context) (*types.Receipt, *types.T
 
 // buildBloatTx builds a bloating transaction without sending it.
 // nextAddressIndex is the starting address index (matching contract's nextStorageSlot semantics).
-func (s *Scenario) buildBloatTx(ctx context.Context, wallet *spamoor.Wallet, startAddressIndex uint64, numAddresses uint64) (*types.Transaction, error) {
+func (s *Scenario) buildBloatTx(ctx context.Context, wallet *spamoor.Wallet, startAddressIndex uint64, numAddresses uint64, gasLimit uint64) (*types.Transaction, error) {
 	client := s.walletPool.GetClient(spamoor.WithClientSelectionMode(spamoor.SelectClientByIndex, 0))
 	if client == nil {
 		return nil, fmt.Errorf("no client available")
@@ -618,9 +696,6 @@ func (s *Scenario) buildBloatTx(ctx context.Context, wallet *spamoor.Wallet, sta
 	if err != nil {
 		return nil, fmt.Errorf("failed to get suggested fees: %w", err)
 	}
-
-	// Use fixed gas limit for simplicity and predictability
-	gasLimit := uint64(FixedGasLimitPerTx)
 
 	// Build transaction using BuildBoundTx
 	tx, err := wallet.BuildBoundTx(ctx, &txbuilder.TxMetadata{

--- a/scenarios/statebloat/erc20_bloater/erc20_bloater.go
+++ b/scenarios/statebloat/erc20_bloater/erc20_bloater.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -247,10 +248,6 @@ func (s *Scenario) Run(ctx context.Context) error {
 	s.logger.Infof("target: %.2f GB = %d addresses (%.2f million)",
 		s.options.TargetStorageGB, targetAddresses, float64(targetAddresses)/1000000)
 
-	gasLimitPerTx, addressesPerTx := s.computeBatchParams()
-	s.logger.Infof("batch sizing: %d addresses per tx, %.2fM gas per tx (amsterdam=%v)",
-		addressesPerTx, float64(gasLimitPerTx)/1000000, s.walletPool.GetTxPool().IsAmsterdam())
-
 	// Start bloating with EIP-7825 compliant transaction splitting
 	totalTxCount := uint64(0)
 	errorCount := 0
@@ -263,177 +260,35 @@ func (s *Scenario) Run(ctx context.Context) error {
 		default:
 		}
 
-		// Calculate how to split transactions for EIP-7825 compliance
-		totalTargetGas := uint64(float64(blockGasLimit) * s.options.TargetGasRatio)
-		txSplits := s.calculateTransactionSplits(totalTargetGas, gasLimitPerTx)
+		// Recomputed every round (not once for the whole run): the chain's
+		// live gas limit can change over a long run, and this also lets the
+		// gas-limit-too-high fallback below only affect the round it fires
+		// on, not the rest of the run.
+		gasLimitPerTx, addressesPerTx := s.computeBatchParams()
 
-		// Log splitting strategy if needed
-		if len(txSplits) > 1 {
-			s.logger.Infof("splitting target gas (%.1fM) across %d transactions (%.1fM gas each)",
-				float64(totalTargetGas)/1000000, len(txSplits), float64(gasLimitPerTx)/1000000)
-		} else {
-			s.logger.Infof("block gas limit: %d, target gas: %d (%.0f%%) - single tx",
-				blockGasLimit, totalTargetGas, s.options.TargetGasRatio*100)
+		newAddressIndex, batchTxCount, err := s.attemptBloatRound(ctx, blockGasLimit, gasLimitPerTx, addressesPerTx, nextAddressIndex, targetAddresses)
+		if err != nil && isGasLimitTooHighError(err) && (gasLimitPerTx != FixedGasLimitPerTx || addressesPerTx != MaxBloatedAddressesPerTx) {
+			// The chain rejected the batch for exceeding the gas limit, which
+			// means it has not actually activated Amsterdam yet even though
+			// spamoor's fee model defaults to assuming it has (see
+			// TxPool.IsAmsterdam's doc comment - it is an operator-set
+			// preference, not a live check against the connected chain).
+			// Retry this one round with the pre-Amsterdam sizing; the next
+			// round tries the Amsterdam sizing again, so throughput recovers
+			// automatically once the chain actually activates it.
+			s.logger.Warnf("batch rejected for exceeding the gas limit (%v); the connected chain does not appear to have activated Amsterdam yet. Retrying this round with pre-Amsterdam batch sizing. Pass --pre-amsterdam-fee-model if this chain will not activate Amsterdam during this run.", err)
+			newAddressIndex, batchTxCount, err = s.attemptBloatRound(ctx, blockGasLimit, FixedGasLimitPerTx, MaxBloatedAddressesPerTx, nextAddressIndex, targetAddresses)
 		}
 
-		// Process batch of transactions for this round
-		roundStartAddressIndex := nextAddressIndex
-		roundSuccess := true
-		batchTxCount := 0
-
-		// Structure to hold transaction data for parallel processing
-		type txBatch struct {
-			tx              *types.Transaction
-			wallet          *spamoor.Wallet
-			numAddresses    uint64
-			gasLimit        uint64
-			endAddressIndex uint64
-		}
-		var txBatches []txBatch
-
-		// Build all transactions first
-		for i := range txSplits {
-			// Use a different wallet for each split transaction to enable parallel submission
-			// Wallet 0 is the deployer, so we use wallets 1, 2, 3, ... for bloating
-			walletIndex := i + 1
-
-			// Ensure we don't exceed available wallets
-			if walletIndex >= s.options.WalletCount {
-				s.logger.Errorf("not enough wallets: need %d but only have %d", walletIndex+1, s.options.WalletCount)
-				roundSuccess = false
-				break
-			}
-
-			wallet := s.walletPool.GetWallet(spamoor.SelectWalletByIndex, walletIndex)
-
-			// Use the maximum number of addresses that fit within gasLimitPerTx
-			numAddresses := addressesPerTx
-
-			// Check if we would exceed our target addresses
-			endAddressIndex := nextAddressIndex + numAddresses
-			if endAddressIndex > targetAddresses {
-				endAddressIndex = targetAddresses
-				numAddresses = endAddressIndex - nextAddressIndex
-			}
-
-			if numAddresses == 0 {
-				break // No more addresses to process
-			}
-
-			s.logger.Debugf("batch %d/%d: processing %d addresses (max per tx) with %dM gas limit",
-				i+1, len(txSplits), numAddresses, gasLimitPerTx/1000000)
-
-			// Build bloating transaction with calculated number of addresses
-			// NOTE: nextAddressIndex is already in address units (matching contract's nextStorageSlot)
-			tx, err := s.buildBloatTx(ctx, wallet, nextAddressIndex, numAddresses, gasLimitPerTx)
-			if err != nil {
-				s.logger.Errorf("failed to build batch tx %d/%d: %v", i+1, len(txSplits), err)
-				roundSuccess = false
-				break
-			}
-
-			txBatches = append(txBatches, txBatch{
-				tx:              tx,
-				wallet:          wallet,
-				numAddresses:    numAddresses,
-				gasLimit:        gasLimitPerTx,
-				endAddressIndex: endAddressIndex,
-			})
-
-			s.logger.WithFields(logrus.Fields{
-				"batch":     fmt.Sprintf("%d/%d", i+1, len(txSplits)),
-				"wallet":    s.walletPool.GetWalletName(wallet.GetAddress()),
-				"addresses": numAddresses,
-				"gas_limit": gasLimitPerTx,
-			}).Debugf("built bloat tx")
-
-			nextAddressIndex = endAddressIndex
-
-			// Break if we've reached target
-			if nextAddressIndex >= targetAddresses {
-				break
-			}
-		}
-
-		if !roundSuccess {
-			// Revert to beginning of round on failure
-			nextAddressIndex = roundStartAddressIndex
-			errorCount++
-			time.Sleep(time.Second * time.Duration(errorCount))
-			continue
-		}
-
-		// Prepare wallet-to-transactions map for SendMultiTransactionBatch
-		walletTxMap := make(map[*spamoor.Wallet][]*types.Transaction)
-		for _, batch := range txBatches {
-			walletTxMap[batch.wallet] = append(walletTxMap[batch.wallet], batch.tx)
-
-			s.logger.WithFields(logrus.Fields{
-				"wallet":    s.walletPool.GetWalletName(batch.wallet.GetAddress()),
-				"tx":        batch.tx.Hash().Hex(),
-				"nonce":     batch.tx.Nonce(),
-				"addresses": batch.numAddresses,
-				"gas_limit": batch.gasLimit,
-			}).Debugf("prepared bloat tx for batch sending")
-		}
-
-		// Send all transactions in parallel using SendMultiTransactionBatch
-		s.logger.Infof("sending %d transactions in parallel from %d wallets", len(txBatches), len(walletTxMap))
-
-		client := s.walletPool.GetClient(spamoor.WithClientSelectionMode(spamoor.SelectClientByIndex, 0))
-
-		receipts, err := s.walletPool.GetTxPool().SendMultiTransactionBatch(ctx, walletTxMap, &spamoor.BatchOptions{
-			SendTransactionOptions: spamoor.SendTransactionOptions{
-				Client:      client,
-				Rebroadcast: true,
-			},
-		})
 		if err != nil {
-			s.logger.Errorf("failed to send transaction batch: %v", err)
-			roundSuccess = false
-		} else {
-			// Process receipts
-			for i, batch := range txBatches {
-				walletReceipts := receipts[batch.wallet]
-				if len(walletReceipts) == 0 {
-					s.logger.Errorf("no receipt for batch tx %d/%d", i+1, len(txBatches))
-					roundSuccess = false
-					break
-				}
-
-				receipt := walletReceipts[0] // Each wallet sends only one tx in our case
-				if receipt.Status != types.ReceiptStatusSuccessful {
-					s.logger.Errorf("tx failed: %s (gas used: %d, gas limit: %d)",
-						batch.tx.Hash().Hex(), receipt.GasUsed, batch.tx.Gas())
-					roundSuccess = false
-					break
-				}
-
-				s.logger.WithFields(logrus.Fields{
-					"batch":    fmt.Sprintf("%d/%d", i+1, len(txBatches)),
-					"tx":       batch.tx.Hash().Hex(),
-					"gas_used": receipt.GasUsed,
-					"block":    receipt.BlockNumber.Uint64(),
-				}).Infof("bloat tx confirmed")
-
-				batchTxCount++
-			}
-
-			if roundSuccess {
-				nextAddressIndex = txBatches[len(txBatches)-1].endAddressIndex
-				totalTxCount += uint64(batchTxCount)
-			}
-		}
-
-		if !roundSuccess {
-			// Revert to beginning of round on failure
-			nextAddressIndex = roundStartAddressIndex
+			s.logger.Errorf("round failed: %v", err)
 			errorCount++
 			time.Sleep(time.Second * time.Duration(errorCount))
 			continue
 		}
 
-		// Reset error count on successful round
+		nextAddressIndex = newAddressIndex
+		totalTxCount += uint64(batchTxCount)
 		errorCount = 0
 
 		// Log progress after successful round
@@ -539,6 +394,182 @@ func (s *Scenario) calculateTransactionSplits(totalTargetGas uint64, gasLimitPer
 	}
 
 	return splits
+}
+
+// isGasLimitTooHighError reports whether err is the rejection a real node
+// returns when a transaction's declared Gas exceeds the EIP-7825 ceiling on
+// a chain that has not activated Amsterdam - go-ethereum's mempool
+// validation returns the literal error "transaction gas limit too high" for
+// this case (core.ErrGasLimitTooHigh), and that text survives being wrapped
+// on its way back through the RPC client and through
+// SendMultiTransactionBatch's own error wrapping.
+func isGasLimitTooHighError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "gas limit too high")
+}
+
+// attemptBloatRound builds and sends one round of bloat transactions using
+// gasLimitPerTx and addressesPerTx, starting from startAddressIndex. It
+// returns the address index to resume from and the number of confirmed
+// transactions on success.
+//
+// On any failure before transactions are confirmed on-chain (a build
+// failure, or a hard rejection at submission), it releases the nonces this
+// attempt allocated via wallet.MarkSkippedNonce so a subsequent retry with
+// different parameters can reuse them instead of leaving a permanent gap in
+// the wallet's nonce sequence. A transaction that reverted on-chain already
+// consumed its nonce legitimately, so those are left alone.
+func (s *Scenario) attemptBloatRound(ctx context.Context, blockGasLimit, gasLimitPerTx, addressesPerTx, startAddressIndex, targetAddresses uint64) (newAddressIndex uint64, txCount int, err error) {
+	totalTargetGas := uint64(float64(blockGasLimit) * s.options.TargetGasRatio)
+	txSplits := s.calculateTransactionSplits(totalTargetGas, gasLimitPerTx)
+
+	if len(txSplits) > 1 {
+		s.logger.Infof("splitting target gas (%.1fM) across %d transactions (%.1fM gas each)",
+			float64(totalTargetGas)/1000000, len(txSplits), float64(gasLimitPerTx)/1000000)
+	} else {
+		s.logger.Infof("block gas limit: %d, target gas: %d (%.0f%%) - single tx",
+			blockGasLimit, totalTargetGas, s.options.TargetGasRatio*100)
+	}
+
+	type txBatch struct {
+		tx              *types.Transaction
+		wallet          *spamoor.Wallet
+		numAddresses    uint64
+		gasLimit        uint64
+		endAddressIndex uint64
+	}
+	var txBatches []txBatch
+	nextAddressIndex := startAddressIndex
+
+	releaseNonces := func() {
+		for _, batch := range txBatches {
+			batch.wallet.MarkSkippedNonce(batch.tx.Nonce())
+		}
+	}
+
+	// Build all transactions first
+	for i := range txSplits {
+		// Use a different wallet for each split transaction to enable parallel submission
+		// Wallet 0 is the deployer, so we use wallets 1, 2, 3, ... for bloating
+		walletIndex := i + 1
+
+		// Ensure we don't exceed available wallets
+		if walletIndex >= s.options.WalletCount {
+			releaseNonces()
+			return startAddressIndex, 0, fmt.Errorf("not enough wallets: need %d but only have %d", walletIndex+1, s.options.WalletCount)
+		}
+
+		wallet := s.walletPool.GetWallet(spamoor.SelectWalletByIndex, walletIndex)
+
+		// Use the maximum number of addresses that fit within gasLimitPerTx
+		numAddresses := addressesPerTx
+
+		// Check if we would exceed our target addresses
+		endAddressIndex := nextAddressIndex + numAddresses
+		if endAddressIndex > targetAddresses {
+			endAddressIndex = targetAddresses
+			numAddresses = endAddressIndex - nextAddressIndex
+		}
+
+		if numAddresses == 0 {
+			break // No more addresses to process
+		}
+
+		s.logger.Debugf("batch %d/%d: processing %d addresses (max per tx) with %dM gas limit",
+			i+1, len(txSplits), numAddresses, gasLimitPerTx/1000000)
+
+		// Build bloating transaction with calculated number of addresses
+		// NOTE: nextAddressIndex is already in address units (matching contract's nextStorageSlot)
+		tx, err := s.buildBloatTx(ctx, wallet, nextAddressIndex, numAddresses, gasLimitPerTx)
+		if err != nil {
+			releaseNonces()
+			return startAddressIndex, 0, fmt.Errorf("failed to build batch tx %d/%d: %w", i+1, len(txSplits), err)
+		}
+
+		txBatches = append(txBatches, txBatch{
+			tx:              tx,
+			wallet:          wallet,
+			numAddresses:    numAddresses,
+			gasLimit:        gasLimitPerTx,
+			endAddressIndex: endAddressIndex,
+		})
+
+		s.logger.WithFields(logrus.Fields{
+			"batch":     fmt.Sprintf("%d/%d", i+1, len(txSplits)),
+			"wallet":    s.walletPool.GetWalletName(wallet.GetAddress()),
+			"addresses": numAddresses,
+			"gas_limit": gasLimitPerTx,
+		}).Debugf("built bloat tx")
+
+		nextAddressIndex = endAddressIndex
+
+		// Break if we've reached target
+		if nextAddressIndex >= targetAddresses {
+			break
+		}
+	}
+
+	if len(txBatches) == 0 {
+		return startAddressIndex, 0, nil
+	}
+
+	// Prepare wallet-to-transactions map for SendMultiTransactionBatch
+	walletTxMap := make(map[*spamoor.Wallet][]*types.Transaction)
+	for _, batch := range txBatches {
+		walletTxMap[batch.wallet] = append(walletTxMap[batch.wallet], batch.tx)
+
+		s.logger.WithFields(logrus.Fields{
+			"wallet":    s.walletPool.GetWalletName(batch.wallet.GetAddress()),
+			"tx":        batch.tx.Hash().Hex(),
+			"nonce":     batch.tx.Nonce(),
+			"addresses": batch.numAddresses,
+			"gas_limit": batch.gasLimit,
+		}).Debugf("prepared bloat tx for batch sending")
+	}
+
+	// Send all transactions in parallel using SendMultiTransactionBatch
+	s.logger.Infof("sending %d transactions in parallel from %d wallets", len(txBatches), len(walletTxMap))
+
+	client := s.walletPool.GetClient(spamoor.WithClientSelectionMode(spamoor.SelectClientByIndex, 0))
+
+	receipts, sendErr := s.walletPool.GetTxPool().SendMultiTransactionBatch(ctx, walletTxMap, &spamoor.BatchOptions{
+		SendTransactionOptions: spamoor.SendTransactionOptions{
+			Client:      client,
+			Rebroadcast: true,
+		},
+	})
+	if sendErr != nil {
+		releaseNonces()
+		return startAddressIndex, 0, fmt.Errorf("failed to send transaction batch: %w", sendErr)
+	}
+
+	// Process receipts
+	batchTxCount := 0
+	for i, batch := range txBatches {
+		walletReceipts := receipts[batch.wallet]
+		if len(walletReceipts) == 0 {
+			releaseNonces()
+			return startAddressIndex, 0, fmt.Errorf("no receipt for batch tx %d/%d", i+1, len(txBatches))
+		}
+
+		receipt := walletReceipts[0] // Each wallet sends only one tx in our case
+		if receipt.Status != types.ReceiptStatusSuccessful {
+			// Mined but reverted: the nonce is legitimately consumed
+			// on-chain, so it is not released here.
+			return startAddressIndex, 0, fmt.Errorf("tx failed: %s (gas used: %d, gas limit: %d)",
+				batch.tx.Hash().Hex(), receipt.GasUsed, batch.tx.Gas())
+		}
+
+		s.logger.WithFields(logrus.Fields{
+			"batch":    fmt.Sprintf("%d/%d", i+1, len(txBatches)),
+			"tx":       batch.tx.Hash().Hex(),
+			"gas_used": receipt.GasUsed,
+			"block":    receipt.BlockNumber.Uint64(),
+		}).Infof("bloat tx confirmed")
+
+		batchTxCount++
+	}
+
+	return txBatches[len(txBatches)-1].endAddressIndex, batchTxCount, nil
 }
 
 // distributeTokensToWallets distributes tokens from wallet 0 to other wallets for parallel execution

--- a/scenarios/statebloat/erc20_bloater/erc20_bloater_test.go
+++ b/scenarios/statebloat/erc20_bloater/erc20_bloater_test.go
@@ -1,0 +1,86 @@
+package erc20bloater
+
+import (
+	"testing"
+
+	"github.com/ethpandaops/spamoor/utils"
+)
+
+// Pre-Amsterdam behavior must stay exactly what it is today: the fixed
+// constants, regardless of whatever gas figures the chain reports.
+func TestCalculateBatchParams_PreAmsterdamUnchanged(t *testing.T) {
+	gasLimit, addresses := calculateBatchParams(false, 45_000_000, 1530, nil)
+	if gasLimit != FixedGasLimitPerTx {
+		t.Fatalf("expected gas limit %d, got %d", FixedGasLimitPerTx, gasLimit)
+	}
+	if addresses != MaxBloatedAddressesPerTx {
+		t.Fatalf("expected %d addresses, got %d", MaxBloatedAddressesPerTx, addresses)
+	}
+}
+
+// On Amsterdam, the batch must be sized from the real state-gas cost per
+// address (2 new slots x 64 bytes x cost_per_state_byte) and the requested
+// gas limit must never exceed the chain's reported ceiling.
+func TestCalculateBatchParams_AmsterdamSizesFromLiveGasLimit(t *testing.T) {
+	const costPerStateByte = 1530
+	const maxTxGas = 45_000_000
+
+	gasLimit, addresses := calculateBatchParams(true, maxTxGas, costPerStateByte, nil)
+
+	statePerAddr := SlotsPerBloatCycle * uint64(64) * uint64(costPerStateByte)
+	wantAddresses := (uint64(maxTxGas) - utils.MaxGasLimitPerTx) / statePerAddr
+	wantGasLimit := utils.MaxGasLimitPerTx + wantAddresses*statePerAddr
+
+	if addresses != wantAddresses {
+		t.Fatalf("expected %d addresses, got %d", wantAddresses, addresses)
+	}
+	if gasLimit != wantGasLimit {
+		t.Fatalf("expected gas limit %d, got %d", wantGasLimit, gasLimit)
+	}
+	if gasLimit > maxTxGas {
+		t.Fatalf("computed gas limit %d exceeds the chain's reported ceiling %d", gasLimit, maxTxGas)
+	}
+	if addresses == 0 {
+		t.Fatal("expected at least one address per tx")
+	}
+}
+
+// If the chain's block gas limit doesn't even clear the legacy EIP-7825
+// ceiling, there is nowhere for a state-gas reservoir to come from at all;
+// this must fall back to the pre-Amsterdam sizing rather than divide by zero
+// or hand back a zero-address batch that can never make progress.
+func TestCalculateBatchParams_FallsBackWhenNoRoomForStateGas(t *testing.T) {
+	gasLimit, addresses := calculateBatchParams(true, 10_000_000, 1530, nil)
+	if gasLimit != FixedGasLimitPerTx || addresses != MaxBloatedAddressesPerTx {
+		t.Fatalf("expected fallback to (%d, %d), got (%d, %d)",
+			FixedGasLimitPerTx, MaxBloatedAddressesPerTx, gasLimit, addresses)
+	}
+}
+
+// A tiny excess over the EIP-7825 ceiling (less than one address's worth of
+// state gas) must still produce at least one address per tx, not zero -
+// zero would mean the scenario silently stalls forever instead of making
+// slow progress.
+func TestCalculateBatchParams_NeverZeroAddresses(t *testing.T) {
+	_, addresses := calculateBatchParams(true, utils.MaxGasLimitPerTx+100, 1530, nil)
+	if addresses != 1 {
+		t.Fatalf("expected exactly 1 address for a near-zero excess budget, got %d", addresses)
+	}
+}
+
+// At an unrealistically large gas ceiling, the regular-gas need for the
+// batch (which is tiny per address but scales with address count) must still
+// be guarded so it never exceeds the mandatory EIP-7825 regular allotment.
+func TestCalculateBatchParams_RegularGasNeverExceedsCeiling(t *testing.T) {
+	const sstoreResetGas = uint64(5000)
+	const loopOverhead = uint64(400)
+	const callOverhead = uint64(300000)
+	regularPerAddr := SlotsPerBloatCycle*sstoreResetGas + loopOverhead
+
+	_, addresses := calculateBatchParams(true, 1_000_000_000, 1530, nil)
+
+	if regularPerAddr*addresses+callOverhead > utils.MaxGasLimitPerTx {
+		t.Fatalf("regular gas need %d for %d addresses exceeds the EIP-7825 regular allotment %d",
+			regularPerAddr*addresses+callOverhead, addresses, utils.MaxGasLimitPerTx)
+	}
+}

--- a/scenarios/statebloat/erc20_bloater/erc20_bloater_test.go
+++ b/scenarios/statebloat/erc20_bloater/erc20_bloater_test.go
@@ -1,8 +1,13 @@
 package erc20bloater
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/ethpandaops/spamoor/spamoor"
 	"github.com/ethpandaops/spamoor/utils"
 )
 
@@ -82,5 +87,119 @@ func TestCalculateBatchParams_RegularGasNeverExceedsCeiling(t *testing.T) {
 	if regularPerAddr*addresses+callOverhead > utils.MaxGasLimitPerTx {
 		t.Fatalf("regular gas need %d for %d addresses exceeds the EIP-7825 regular allotment %d",
 			regularPerAddr*addresses+callOverhead, addresses, utils.MaxGasLimitPerTx)
+	}
+}
+
+// wouldBeRejectedPreAmsterdam mirrors, verbatim, the EIP-7825 check
+// go-ethereum's mempool applies at core/txpool/validation.go: on a chain
+// that has activated Osaka but not yet Amsterdam, any tx.Gas() above
+// params.MaxTxGas is rejected before the transaction ever reaches a block.
+func wouldBeRejectedPreAmsterdam(rules params.Rules, txGas uint64) bool {
+	return rules.IsOsaka && !rules.IsAmsterdam && txGas > params.MaxTxGas
+}
+
+// TestCalculateBatchParams_DefaultFlagRejectedOnPreAmsterdamOsakaChain is a
+// mechanical reproduction of the finding that spamoor's IsAmsterdam() is a
+// static operator preference (defaults to true) rather than live on-chain
+// fork detection. On a chain that is Osaka-active but has not yet activated
+// Amsterdam - exactly the state of any devnet before it crosses the fork
+// boundary described in the underlying issue - the batch size this scenario
+// computes by default would be rejected outright by a real node, not merely
+// reverted on-chain.
+func TestCalculateBatchParams_DefaultFlagRejectedOnPreAmsterdamOsakaChain(t *testing.T) {
+	for _, blockGasLimit := range []uint64{30_000_000, 45_000_000, 60_000_000} {
+		// isAmsterdam=true is exactly what TxPool.IsAmsterdam() returns with
+		// default spamoor flags; no misconfiguration is needed to reach this.
+		gasLimitPerTx, addressesPerTx := calculateBatchParams(true, blockGasLimit, spamoor.CostPerStateByte, nil)
+
+		if gasLimitPerTx <= utils.MaxGasLimitPerTx {
+			t.Fatalf("block gas limit %d: expected gasLimitPerTx to exceed the EIP-7825 ceiling (%d), got %d (addresses=%d) - test assumption invalid",
+				blockGasLimit, utils.MaxGasLimitPerTx, gasLimitPerTx, addressesPerTx)
+		}
+
+		// The exact rejection condition from go-ethereum's real mempool
+		// validation, applied to the value this scenario would actually put
+		// in the transaction's Gas field.
+		preAmsterdamOsaka := params.Rules{IsOsaka: true, IsAmsterdam: false}
+		if !wouldBeRejectedPreAmsterdam(preAmsterdamOsaka, gasLimitPerTx) {
+			t.Fatalf("block gas limit %d: expected gasLimitPerTx=%d to be rejected on a pre-Amsterdam Osaka chain, but the real validation condition says it would be accepted",
+				blockGasLimit, gasLimitPerTx)
+		}
+
+		// Control: the identical value is accepted once Amsterdam has
+		// actually activated, proving the rejection is specifically about
+		// the fork mismatch and not just "large numbers always fail."
+		amsterdam := params.Rules{IsOsaka: true, IsAmsterdam: true}
+		if wouldBeRejectedPreAmsterdam(amsterdam, gasLimitPerTx) {
+			t.Fatalf("block gas limit %d: gasLimitPerTx=%d unexpectedly rejected even once the chain has activated Amsterdam",
+				blockGasLimit, gasLimitPerTx)
+		}
+
+		t.Logf("CONFIRMED: block gas limit %d -> computed gasLimitPerTx=%d (%d addresses) exceeds the EIP-7825 ceiling %d; rejected pre-Amsterdam, accepted post-Amsterdam",
+			blockGasLimit, gasLimitPerTx, addressesPerTx, utils.MaxGasLimitPerTx)
+	}
+}
+
+// TestIsGasLimitTooHighError verifies the detection helper recognizes the
+// real go-ethereum rejection text through the exact wrapping chain
+// SendMultiTransactionBatch and attemptBloatRound apply to it, and does not
+// false-positive on unrelated errors - including other errors that also
+// mention "gas" or "limit" individually.
+func TestIsGasLimitTooHighError(t *testing.T) {
+	// Mirrors the real wrapping chain: core.ErrGasLimitTooHigh, wrapped by
+	// the per-tx submit retry loop, wrapped by SendMultiTransactionBatch's
+	// per-wallet aggregation, wrapped by attemptBloatRound.
+	wrapped := fmt.Errorf("failed to send transaction batch: %w",
+		fmt.Errorf("wallet 0xabc transaction 0 failed: %w",
+			fmt.Errorf("failed to submit after 1 attempts: %w",
+				fmt.Errorf("transaction gas limit too high (cap: %d, tx: %d)", utils.MaxGasLimitPerTx, 45_000_000))))
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"exact geth error text", errors.New("transaction gas limit too high"), true},
+		{"geth error with cap/tx detail", fmt.Errorf("transaction gas limit too high (cap: %d, tx: %d)", utils.MaxGasLimitPerTx, 45_000_000), true},
+		{"wrapped through the real call chain", wrapped, true},
+		{"unrelated context error", errors.New("context deadline exceeded"), false},
+		{"unrelated error that also mentions gas", errors.New("insufficient funds for gas * price + value"), false},
+		{"unrelated error that also mentions limit", errors.New("rate limit exceeded"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isGasLimitTooHighError(tt.err); got != tt.want {
+				t.Fatalf("isGasLimitTooHighError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCalculateBatchParams_FallbackSizingNeverExceedsLegacyCeiling is the
+// other half of the fix's proof: TestCalculateBatchParams_DefaultFlagRejectedOnPreAmsterdamOsakaChain
+// shows the optimistic (Amsterdam-assumed) sizing gets rejected on a
+// pre-Amsterdam Osaka chain. This shows the exact fallback values Run() uses
+// once that rejection is detected - the same constants calculateBatchParams
+// itself returns when isAmsterdam is false - are never subject to that
+// rejection at all, at any block gas limit.
+func TestCalculateBatchParams_FallbackSizingNeverExceedsLegacyCeiling(t *testing.T) {
+	if FixedGasLimitPerTx > utils.MaxGasLimitPerTx {
+		t.Fatalf("FixedGasLimitPerTx (%d) exceeds the EIP-7825 ceiling (%d)", FixedGasLimitPerTx, utils.MaxGasLimitPerTx)
+	}
+
+	preAmsterdamOsaka := params.Rules{IsOsaka: true, IsAmsterdam: false}
+	if wouldBeRejectedPreAmsterdam(preAmsterdamOsaka, FixedGasLimitPerTx) {
+		t.Fatalf("FixedGasLimitPerTx (%d) would be rejected on a pre-Amsterdam Osaka chain", FixedGasLimitPerTx)
+	}
+
+	// Same fallback values regardless of how large the (possibly stale or
+	// misreported) block gas limit that triggered the fallback was.
+	for _, blockGasLimit := range []uint64{10_000_000, 30_000_000, 45_000_000, 60_000_000} {
+		gasLimit, addresses := calculateBatchParams(false, blockGasLimit, spamoor.CostPerStateByte, nil)
+		if gasLimit != FixedGasLimitPerTx || addresses != MaxBloatedAddressesPerTx {
+			t.Fatalf("block gas limit %d: expected fallback (%d, %d), got (%d, %d)",
+				blockGasLimit, FixedGasLimitPerTx, MaxBloatedAddressesPerTx, gasLimit, addresses)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #260

Under Amsterdam (EIP-8037), creating a new storage slot also charges state-creation gas from a second, separate budget. A transaction only receives a share of that budget once its total requested gas exceeds the EIP-7825 ceiling; anything at or below that ceiling gets a state-gas reservoir of exactly zero, so every new slot's state-creation cost spills entirely into regular gas instead.

bloatStorage() deliberately stayed just under that ceiling to satisfy EIP-7825, which is exactly what starved it of any state-gas reservoir. Every bloat transaction then needed roughly 4-5x the gas the fixed batch size assumed, and reverted out of gas partway through the loop.

The per-transaction gas limit and address count are now computed from the chain's live fork state and gas ceiling instead of a fixed constant, mirroring the approach already used in storagerefundtx. Batches are smaller than before on Amsterdam chains since the real per-address cost is much higher than the old model assumed, so reaching the same target storage size takes correspondingly more transactions.

That alone isn't quite enough on its own, though. TxPool.IsAmsterdam() is a static, operator-set preference that defaults to true, not a live check against what the connected chain has actually activated. On a chain that is Osaka-active but not yet Amsterdam-active, a transaction whose gas exceeds the EIP-7825 ceiling is rejected outright before it ever reaches a block, so a run spanning the Amsterdam activation boundary would have every pre-fork transaction rejected, which is a worse failure than the original revert.

To handle that, the per-round send logic is now retried once with the pre-Amsterdam sizing whenever a round is rejected specifically for exceeding the gas limit. Nothing is cached across rounds, so the next round tries the Amsterdam sizing again and throughput recovers on its own once the chain actually activates Amsterdam. Nonces from rejected-at-submission transactions are released so the retry can reuse them instead of leaving a gap; transactions that revert on-chain are left alone since those nonces are already legitimately consumed.

Pre-Amsterdam behavior (no override, chain never touches the Amsterdam path) is unchanged throughout.