### PR TITLE
Only mark the batcher deployed once it actually succeeds

### DIFF
--- a/spamoor/txbatcher.go
+++ b/spamoor/txbatcher.go
@@ -151,8 +151,6 @@ func (b *TxBatcher) Deploy(ctx context.Context, wallet *Wallet, client *Client) 
 		return nil
 	}
 
-	b.isDeployed = true
-
 	compiler := geas.NewCompiler(nil)
 
 	initcode := compiler.CompileString(batcherGeasInit)
@@ -173,6 +171,13 @@ func (b *TxBatcher) Deploy(ctx context.Context, wallet *Wallet, client *Client) 
 	}
 
 	b.address = contractAddr
+	// Only mark as deployed once we actually have a real address: marking it
+	// before the fallible deployment step meant a transient failure left
+	// isDeployed permanently true with address still zero, so every later
+	// call short-circuited to "success" with a zero address, and every
+	// funding transaction built against it became a real-value transfer to
+	// the zero address instead of a contract creation.
+	b.isDeployed = true
 
 	return nil
 }

--- a/spamoor/txbatcher_test.go
+++ b/spamoor/txbatcher_test.go
@@ -1,0 +1,55 @@
+package spamoor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// txBatcherWithNoClients builds a real TxBatcher whose deployment fails
+// deterministically with no network: GetContractDeployment needs a client
+// from the pool, and an empty ClientPool always returns nil.
+func txBatcherWithNoClients() *TxBatcher {
+	pool := &TxPool{options: &TxPoolOptions{ClientPool: &ClientPool{}}}
+	factory := &DeploymentFactory{txpool: pool}
+	return &TxBatcher{txpool: pool, factory: factory}
+}
+
+// A failed deployment must not leave the batcher marked as deployed with a
+// zero address - that would make every subsequent Deploy() call silently
+// report success while every funding transaction built against GetAddress()
+// becomes a real-value transfer to the zero address instead of reaching the
+// batcher contract.
+func TestDeploy_FailedDeploymentDoesNotMarkAsDeployed(t *testing.T) {
+	batcher := txBatcherWithNoClients()
+
+	err := batcher.Deploy(context.Background(), nil, nil)
+	if err == nil {
+		t.Fatal("expected Deploy to fail with no client available")
+	}
+
+	if batcher.isDeployed {
+		t.Fatal("expected isDeployed to stay false after a failed deploy")
+	}
+	if batcher.GetAddress() != (common.Address{}) {
+		t.Fatalf("expected address to stay zero after a failed deploy, got %s", batcher.GetAddress())
+	}
+}
+
+// A failed deployment must be retriable: a later Deploy() call has to
+// actually attempt deployment again rather than short-circuiting to a stale
+// "success" left over from the earlier failure.
+func TestDeploy_FailedDeploymentAllowsRetry(t *testing.T) {
+	batcher := txBatcherWithNoClients()
+
+	_ = batcher.Deploy(context.Background(), nil, nil)
+
+	err := batcher.Deploy(context.Background(), nil, nil)
+	if err == nil {
+		t.Fatal("expected the retry to also fail (still no client available), not silently report success")
+	}
+	if batcher.GetAddress() != (common.Address{}) {
+		t.Fatalf("expected address to stay zero, got %s", batcher.GetAddress())
+	}
+}


### PR DESCRIPTION
Deploy() set isDeployed true before the fallible compile and on-chain deployment steps. A transient failure during either left isDeployed permanently true with the address still zero, so every later Deploy() call short-circuited to success without ever deploying anything.

That mattered beyond a stuck flag: every funding transaction built against GetAddress() afterward became a real-value transfer to the zero address instead of reaching the batcher contract, and child wallets never actually got credited since the funds never reached them either.

isDeployed is now set only after the address is actually assigned, so a failed deployment stays retriable instead of getting stuck in a false success.

Added tests covering a failed deploy leaving isDeployed false with a zero address, and a failed deploy allowing a genuine retry rather than a silent stale success.