### PR TITLE
Stop leaking goroutines when multiple submissions fail together

### DIFF
--- a/spamoor/submitter.go
+++ b/spamoor/submitter.go
@@ -385,7 +385,20 @@ func (p *TxPool) SendMultiTransactionBatch(ctx context.Context, walletTxs map[*W
 					var finalErr error
 					if lastErr != nil {
 						finalErr = fmt.Errorf("failed to submit after %d attempts: %w", maxRetries, lastErr)
-						state.errorChan <- lastErr // Signal hard error
+
+						// Best-effort signal: errorChan has capacity 1 and the
+						// manager below only ever drains one error from it
+						// before cancelling and returning. Once that happens,
+						// nothing drains it again, so a blocking send here
+						// would leave every other failing sub-goroutine for
+						// this wallet stuck forever, never releasing its
+						// semaphore slot. The error is still recorded in
+						// errors[wallet][txIndex] below regardless of whether
+						// this send lands.
+						select {
+						case state.errorChan <- lastErr:
+						default:
+						}
 					}
 
 					resultsMutex.Lock()

--- a/spamoor/submitter_test.go
+++ b/spamoor/submitter_test.go
@@ -1,0 +1,64 @@
+package spamoor
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestSubmitBatchErrorSignal_MultipleHardFailuresDoNotLeakGoroutines mirrors
+// the exact per-wallet manager / sub-goroutine structure in
+// SendMultiTransactionBatch: a size-1 error channel that the manager drains
+// at most once before cancelling and returning. Before the fix, every
+// sub-goroutine past the first to hit a hard failure blocked forever on an
+// unconditional send to that channel, since nothing ever drained it again
+// after the manager returned - leaking the goroutine and, in the real code,
+// its semaphore slot permanently.
+//
+// Reaching submitter.go's real channel through SendMultiTransactionBatch's
+// full RPC-submission path cannot be done deterministically without a live
+// network, so this drives the exact channel structure and the fixed
+// best-effort send pattern directly, with a bounded timeout so a
+// regression fails fast instead of hanging the test suite.
+func TestSubmitBatchErrorSignal_MultipleHardFailuresDoNotLeakGoroutines(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	errorChan := make(chan error, 1)  // same capacity as batchState.errorChan
+	completeChan := make(chan int, 8) // same sizing pattern as batchState.completeChan
+
+	const subs = 8
+	go func() { // manager
+		for i := 0; i < subs; i++ {
+			go func(i int) { // sub-goroutine
+				defer func() { completeChan <- i }()
+
+				// The fixed send pattern: best effort, never blocks even
+				// once the manager below has stopped listening.
+				select {
+				case errorChan <- context.DeadlineExceeded:
+				default:
+				}
+			}(i)
+		}
+		<-errorChan // manager drains exactly one, then stops listening entirely
+	}()
+
+	completed := 0
+	timeout := time.After(2 * time.Second)
+	for completed < subs {
+		select {
+		case <-completeChan:
+			completed++
+		case <-timeout:
+			t.Fatalf("only %d of %d sub-goroutines completed within the timeout; the rest are blocked on the error send", completed, subs)
+		}
+	}
+
+	// All sub-goroutines completed; confirm none of them are lingering in
+	// the runtime for some other unexpected reason.
+	time.Sleep(20 * time.Millisecond)
+	if after := runtime.NumGoroutine(); after > before+2 {
+		t.Fatalf("expected goroutine count to settle back down, got %d before, %d after", before, after)
+	}
+}


### PR DESCRIPTION
## Summary
- The manager for a wallet's batch submission drains only the first error from a size-1 error channel, then stops listening. Every other failing sub-goroutine was doing an unconditional blocking send on that same channel, so once the manager stopped draining, they blocked forever with no way to release their semaphore slot or run their own cleanup.
- Changed the send to a non-blocking best-effort select, so a sub-goroutine that fails after the manager has already moved on drops its error instead of hanging.

## Test plan
- Added a test that mirrors the manager/sub-goroutine channel structure with several sub-goroutines failing at once, and checks no goroutines are left running after the manager returns.
- Verified the test fails against the old blocking send and passes with the fix, under `-race`.