### PR TITLE
Fix ReclaimFunds hanging forever when the context is cancelled mid-sweep

### DIFF
--- a/spamoor/txpool.go
+++ b/spamoor/txpool.go
@@ -1026,6 +1026,13 @@ func (pool *TxPool) calculateAllWalletPoolStats(confirmedTxMap map[common.Hash]*
 // whether to immediately submit or just set up confirmation tracking.
 func (pool *TxPool) submitTransaction(ctx context.Context, wallet *Wallet, tx *types.Transaction, options *SendTransactionOptions, submitNow bool) error {
 	if ctx.Err() != nil {
+		// OnComplete is documented as always called regardless of success/failure.
+		// Callers that rely on it firing to release a WaitGroup or semaphore (e.g.
+		// WalletPool.ReclaimFunds) would otherwise hang forever if the context is
+		// already cancelled by the time this call is dispatched.
+		if options.OnComplete != nil {
+			options.OnComplete(tx, nil, ctx.Err())
+		}
 		return ctx.Err()
 	}
 

--- a/spamoor/txpool_reclaim_oncomplete_test.go
+++ b/spamoor/txpool_reclaim_oncomplete_test.go
@@ -1,0 +1,100 @@
+package spamoor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// TestSendTransaction_OnCompleteFiresWhenContextAlreadyCancelled drives the
+// real SendTransaction/submitTransaction path with a context that is already
+// cancelled before the call is made. OnComplete is documented as "always
+// called regardless of success/failure", but the early ctx.Err() guard used
+// to return before ever setting up the goroutine that calls it. Any caller
+// that relies on OnComplete firing to release a WaitGroup or semaphore (see
+// WalletPool.ReclaimFunds) would hang forever in that case.
+func TestSendTransaction_OnCompleteFiresWhenContextAlreadyCancelled(t *testing.T) {
+	pool := &TxPool{}
+	wallet := &Wallet{}
+	tx := types.NewTx(&types.LegacyTx{Nonce: 0})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var called bool
+	var gotErr error
+	done := make(chan struct{})
+
+	err := pool.SendTransaction(ctx, wallet, tx, &SendTransactionOptions{
+		OnComplete: func(_ *types.Transaction, _ *types.Receipt, err error) {
+			called = true
+			gotErr = err
+			close(done)
+		},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnComplete was never called for an already-cancelled context")
+	}
+
+	if !called {
+		t.Fatal("OnComplete was not called")
+	}
+	if gotErr == nil {
+		t.Fatal("expected OnComplete to receive the context error, got nil")
+	}
+	if err == nil {
+		t.Fatal("expected SendTransaction to return the context error")
+	}
+}
+
+// TestReclaimFundsPattern_DoesNotHangWhenContextAlreadyCancelled mirrors the
+// exact synchronization structure ReclaimFunds (walletpool.go) uses: one
+// goroutine per transaction calls the real SendTransaction, and wg.Done() is
+// only ever called from inside OnComplete - the dispatching goroutine itself
+// does not call it. ReclaimFunds needs a live client and funded wallets to
+// reach this point, which is infeasible to set up here, so this drives the
+// same wg/OnComplete wiring directly against the real SendTransaction with a
+// context that is already cancelled, exactly as it would be if a daemon
+// shutdown or a spammer Pause cancelled the context while a batch of reclaim
+// transactions was still being dispatched.
+func TestReclaimFundsPattern_DoesNotHangWhenContextAlreadyCancelled(t *testing.T) {
+	pool := &TxPool{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	const txCount = 50
+	var wg sync.WaitGroup
+	wg.Add(txCount)
+
+	for i := 0; i < txCount; i++ {
+		wallet := &Wallet{}
+		tx := types.NewTx(&types.LegacyTx{Nonce: uint64(i)})
+
+		go func() {
+			pool.SendTransaction(ctx, wallet, tx, &SendTransactionOptions{
+				OnComplete: func(_ *types.Transaction, _ *types.Receipt, _ error) {
+					wg.Done()
+				},
+			})
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReclaimFunds-style wg.Wait() hung after context was already cancelled before dispatch")
+	}
+}


### PR DESCRIPTION
## Summary
- OnComplete is documented as always being called once transaction processing finishes, regardless of success or failure. The guard that returns early when the context is already cancelled skipped that contract entirely, returning before the callback was ever wired up.
- ReclaimFunds depends on that contract: it fires one goroutine per wallet to send a reclaim transaction and only calls wg.Done() from inside OnComplete, then waits on the group. Both a daemon shutdown and a spammer pause cancel the same context passed down to these sends, so any reclaim still being dispatched at that moment would never release its slot in the wait group, leaving the whole reclaim, and the spammer run it belongs to, stuck forever with no timeout to recover.
- The early-return path now calls OnComplete with the context error before returning, so every caller relying on it firing keeps working correctly once the context is cancelled.

## Test plan
- Added a test driving the real transaction submission path with an already-cancelled context, asserting OnComplete still fires.
- Added a test mirroring ReclaimFunds's own wait group wiring end to end, confirming it no longer hangs.
- Both verified to fail against the previous behavior and pass with the fix, under `-race`.